### PR TITLE
Implement etcd metadata store with path resolver and CRUD operations to setup up the metadata infrastructure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,13 @@
             <version>2.0.7</version>
         </dependency>
         
+        <!-- etcd Client -->
+        <dependency>
+            <groupId>io.etcd</groupId>
+            <artifactId>jetcd-core</artifactId>
+            <version>0.7.3</version>
+        </dependency>
+        
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -62,9 +69,17 @@
             <scope>test</scope>
         </dependency>
         
+        
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <version>5.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <version>5.5.0</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/io/clustercontroller/config/Constants.java
+++ b/src/main/java/io/clustercontroller/config/Constants.java
@@ -31,4 +31,21 @@ public final class Constants {
     public static final String TASK_ACTION_DISCOVER_SEARCH_UNIT = "discover_search_unit";
     public static final String TASK_ACTION_SHARD_ALLOCATOR = "shard_allocator";
     public static final String TASK_ACTION_ACTUAL_ALLOCATION_UPDATER = "actual_allocation_updater";
+    
+    // etcd path segments
+    public static final String PATH_CTL_TASKS = "ctl-tasks";
+    public static final String PATH_SEARCH_UNITS = "search-units";
+    public static final String PATH_INDICES = "indices";
+    public static final String PATH_COORDINATORS = "coordinators";
+    public static final String PATH_SHARD = "shard";
+    public static final String PATH_LEADER_ELECTION = "leader-election";
+    
+    // etcd path suffixes
+    public static final String SUFFIX_CONF = "conf";
+    public static final String SUFFIX_GOAL_STATE = "goal-state";
+    public static final String SUFFIX_ACTUAL_STATE = "actual-state";
+    public static final String SUFFIX_MAPPINGS = "mappings";
+    public static final String SUFFIX_SETTINGS = "settings";
+    public static final String SUFFIX_PLANNED_ALLOCATION = "planned-allocation";
+    public static final String SUFFIX_ACTUAL_ALLOCATION = "actual-allocation";
 }

--- a/src/main/java/io/clustercontroller/config/Constants.java
+++ b/src/main/java/io/clustercontroller/config/Constants.java
@@ -33,6 +33,7 @@ public final class Constants {
     public static final String TASK_ACTION_ACTUAL_ALLOCATION_UPDATER = "actual_allocation_updater";
     
     // etcd path segments
+    public static final String PATH_DELIMITER = "/";
     public static final String PATH_CTL_TASKS = "ctl-tasks";
     public static final String PATH_SEARCH_UNITS = "search-units";
     public static final String PATH_INDICES = "indices";

--- a/src/main/java/io/clustercontroller/store/EtcdMetadataStore.java
+++ b/src/main/java/io/clustercontroller/store/EtcdMetadataStore.java
@@ -1,11 +1,24 @@
 package io.clustercontroller.store;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.clustercontroller.models.SearchUnit;
 import io.clustercontroller.models.TaskMetadata;
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KV;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.kv.PutResponse;
+import io.etcd.jetcd.options.GetOption;
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 /**
  * etcd-based implementation of MetadataStore.
@@ -14,11 +27,17 @@ import java.util.Optional;
 @Slf4j
 public class EtcdMetadataStore implements MetadataStore {
     
+    // TODO: Make etcd timeout configurable via environment variable or config
+    private static final long ETCD_OPERATION_TIMEOUT_SECONDS = 5;
+    
     private static EtcdMetadataStore instance;
     
     private final String clusterName;
     private final String[] etcdEndpoints;
-    // private final Client etcdClient;
+    private final Client etcdClient;
+    private final KV kvClient;
+    private final EtcdPathResolver pathResolver;
+    private final ObjectMapper objectMapper;
     
     /**
      * Private constructor for singleton pattern
@@ -27,10 +46,20 @@ public class EtcdMetadataStore implements MetadataStore {
         this.clusterName = clusterName;
         this.etcdEndpoints = etcdEndpoints;
         
-        // Initialize etcd client
-        // this.etcdClient = Client.builder().endpoints(etcdEndpoints).build();
+        // Initialize Jackson ObjectMapper
+        this.objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         
-        log.info("EtcdMetadataStore initialized for cluster: {}", clusterName);
+        // Initialize etcd client
+        this.etcdClient = Client.builder().endpoints(etcdEndpoints).build();
+        this.kvClient = etcdClient.getKVClient();
+        
+        // Initialize path resolver
+        this.pathResolver = new EtcdPathResolver(clusterName);
+        
+        log.info("EtcdMetadataStore initialized for cluster: {} with endpoints: {}", 
+            clusterName, String.join(",", etcdEndpoints));
     }
     
     /**
@@ -60,34 +89,125 @@ public class EtcdMetadataStore implements MetadataStore {
     @Override
     public List<TaskMetadata> getAllTasks() throws Exception {
         log.debug("Getting all tasks from etcd");
-        // TODO: etcd.getKVClient().get() with prefix
-        return List.of();
+        
+        try {
+            String tasksPrefix = pathResolver.getControllerTasksPrefix();
+            ByteSequence prefixBytes = ByteSequence.from(tasksPrefix, StandardCharsets.UTF_8);
+            
+            GetResponse response = kvClient.get(
+                prefixBytes,
+                GetOption.newBuilder().withPrefix(prefixBytes).build()
+            ).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            List<TaskMetadata> tasks = new ArrayList<>();
+            for (var kv : response.getKvs()) {
+                String taskJson = kv.getValue().toString(StandardCharsets.UTF_8);
+                TaskMetadata task = objectMapper.readValue(taskJson, TaskMetadata.class);
+                tasks.add(task);
+            }
+            
+            // Sort by priority (0 = highest priority)
+            tasks.sort((t1, t2) -> Integer.compare(t1.getPriority(), t2.getPriority()));
+            
+            log.debug("Retrieved {} tasks from etcd", tasks.size());
+            return tasks;
+            
+        } catch (Exception e) {
+            log.error("Failed to get all tasks from etcd: {}", e.getMessage(), e);
+            throw new Exception("Failed to retrieve tasks from etcd", e);
+        }
     }
     
     @Override
     public Optional<TaskMetadata> getTask(String taskName) throws Exception {
         log.debug("Getting task {} from etcd", taskName);
-        // TODO: etcd.getKVClient().get(taskPath)
-        return Optional.empty();
+        
+        try {
+            String taskPath = pathResolver.getControllerTaskPath(taskName);
+            ByteSequence keyBytes = ByteSequence.from(taskPath, StandardCharsets.UTF_8);
+            
+            GetResponse response = kvClient.get(keyBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            if (response.getCount() == 0) {
+                log.debug("Task {} not found in etcd", taskName);
+                return Optional.empty();
+            }
+            
+            String taskJson = response.getKvs().get(0).getValue().toString(StandardCharsets.UTF_8);
+            TaskMetadata task = objectMapper.readValue(taskJson, TaskMetadata.class);
+            
+            log.debug("Retrieved task {} from etcd", taskName);
+            return Optional.of(task);
+            
+        } catch (Exception e) {
+            log.error("Failed to get task {} from etcd: {}", taskName, e.getMessage(), e);
+            throw new Exception("Failed to retrieve task from etcd", e);
+        }
     }
     
     @Override
     public String createTask(TaskMetadata task) throws Exception {
         log.info("Creating task {} in etcd", task.getName());
-        // TODO: etcd.getKVClient().put(taskPath, taskJson)
-        return task.getName();
+        
+        try {
+            String taskPath = pathResolver.getControllerTaskPath(task.getName());
+            String taskJson = objectMapper.writeValueAsString(task);
+            
+            ByteSequence keyBytes = ByteSequence.from(taskPath, StandardCharsets.UTF_8);
+            ByteSequence valueBytes = ByteSequence.from(taskJson, StandardCharsets.UTF_8);
+            
+            PutResponse response = kvClient.put(keyBytes, valueBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            log.info("Successfully created task {} in etcd", task.getName());
+            return task.getName();
+            
+        } catch (Exception e) {
+            log.error("Failed to create task {} in etcd: {}", task.getName(), e.getMessage(), e);
+            throw new Exception("Failed to create task in etcd", e);
+        }
     }
     
     @Override
     public void updateTask(TaskMetadata task) throws Exception {
         log.debug("Updating task {} in etcd", task.getName());
-        // TODO: etcd.getKVClient().put(taskPath, taskJson)
+        
+        try {
+            String taskPath = pathResolver.getControllerTaskPath(task.getName());
+            String taskJson = objectMapper.writeValueAsString(task);
+            
+            ByteSequence keyBytes = ByteSequence.from(taskPath, StandardCharsets.UTF_8);
+            ByteSequence valueBytes = ByteSequence.from(taskJson, StandardCharsets.UTF_8);
+            
+            kvClient.put(keyBytes, valueBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            log.debug("Successfully updated task {} in etcd", task.getName());
+            
+        } catch (Exception e) {
+            log.error("Failed to update task {} in etcd: {}", task.getName(), e.getMessage(), e);
+            throw new Exception("Failed to update task in etcd", e);
+        }
     }
     
     @Override
     public void deleteTask(String taskName) throws Exception {
         log.info("Deleting task {} from etcd", taskName);
-        // TODO: etcd.getKVClient().delete(taskPath)
+        
+        try {
+            String taskPath = pathResolver.getControllerTaskPath(taskName);
+            ByteSequence keyBytes = ByteSequence.from(taskPath, StandardCharsets.UTF_8);
+            
+            var response = kvClient.delete(keyBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            if (response.getDeleted() > 0) {
+                log.info("Successfully deleted task {} from etcd", taskName);
+            } else {
+                log.warn("Task {} not found in etcd for deletion", taskName);
+            }
+            
+        } catch (Exception e) {
+            log.error("Failed to delete task {} from etcd: {}", taskName, e.getMessage(), e);
+            throw new Exception("Failed to delete task from etcd", e);
+        }
     }
     
     @Override
@@ -103,33 +223,121 @@ public class EtcdMetadataStore implements MetadataStore {
     @Override
     public List<SearchUnit> getAllSearchUnits() throws Exception {
         log.debug("Getting all search units from etcd");
-        // TODO: etcd.getKVClient().get() with prefix
-        return List.of();
+        
+        try {
+            String unitsPrefix = pathResolver.getSearchUnitsPrefix();
+            ByteSequence prefixBytes = ByteSequence.from(unitsPrefix, StandardCharsets.UTF_8);
+            
+            GetResponse response = kvClient.get(
+                prefixBytes,
+                GetOption.newBuilder().withPrefix(prefixBytes).build()
+            ).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            List<SearchUnit> searchUnits = new ArrayList<>();
+            for (var kv : response.getKvs()) {
+                String unitJson = kv.getValue().toString(StandardCharsets.UTF_8);
+                SearchUnit unit = objectMapper.readValue(unitJson, SearchUnit.class);
+                searchUnits.add(unit);
+            }
+            
+            log.debug("Retrieved {} search units from etcd", searchUnits.size());
+            return searchUnits;
+            
+        } catch (Exception e) {
+            log.error("Failed to get all search units from etcd: {}", e.getMessage(), e);
+            throw new Exception("Failed to retrieve search units from etcd", e);
+        }
     }
     
     @Override
     public Optional<SearchUnit> getSearchUnit(String unitName) throws Exception {
         log.debug("Getting search unit {} from etcd", unitName);
-        // TODO: etcd.getKVClient().get(unitPath)
-        return Optional.empty();
+        
+        try {
+            String unitPath = pathResolver.getSearchUnitConfPath(unitName);
+            ByteSequence keyBytes = ByteSequence.from(unitPath, StandardCharsets.UTF_8);
+            
+            GetResponse response = kvClient.get(keyBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            if (response.getCount() == 0) {
+                log.debug("Search unit {} not found in etcd", unitName);
+                return Optional.empty();
+            }
+            
+            String unitJson = response.getKvs().get(0).getValue().toString(StandardCharsets.UTF_8);
+            SearchUnit unit = objectMapper.readValue(unitJson, SearchUnit.class);
+            
+            log.debug("Retrieved search unit {} from etcd", unitName);
+            return Optional.of(unit);
+            
+        } catch (Exception e) {
+            log.error("Failed to get search unit {} from etcd: {}", unitName, e.getMessage(), e);
+            throw new Exception("Failed to retrieve search unit from etcd", e);
+        }
     }
     
     @Override
     public void upsertSearchUnit(String unitName, SearchUnit searchUnit) throws Exception {
         log.info("Upserting search unit {} in etcd", unitName);
-        // TODO: etcd.getKVClient().put(unitPath, unitJson)
+        
+        try {
+            String unitPath = pathResolver.getSearchUnitConfPath(unitName);
+            String unitJson = objectMapper.writeValueAsString(searchUnit);
+            
+            ByteSequence keyBytes = ByteSequence.from(unitPath, StandardCharsets.UTF_8);
+            ByteSequence valueBytes = ByteSequence.from(unitJson, StandardCharsets.UTF_8);
+            
+            kvClient.put(keyBytes, valueBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            log.info("Successfully upserted search unit {} in etcd", unitName);
+            
+        } catch (Exception e) {
+            log.error("Failed to upsert search unit {} in etcd: {}", unitName, e.getMessage(), e);
+            throw new Exception("Failed to upsert search unit in etcd", e);
+        }
     }
     
     @Override
     public void updateSearchUnit(SearchUnit searchUnit) throws Exception {
         log.debug("Updating search unit {} in etcd", searchUnit.getName());
-        // TODO: etcd.getKVClient().put(unitPath, unitJson)
+        
+        try {
+            String unitPath = pathResolver.getSearchUnitConfPath(searchUnit.getName());
+            String unitJson = objectMapper.writeValueAsString(searchUnit);
+            
+            ByteSequence keyBytes = ByteSequence.from(unitPath, StandardCharsets.UTF_8);
+            ByteSequence valueBytes = ByteSequence.from(unitJson, StandardCharsets.UTF_8);
+            
+            kvClient.put(keyBytes, valueBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            log.debug("Successfully updated search unit {} in etcd", searchUnit.getName());
+            
+        } catch (Exception e) {
+            log.error("Failed to update search unit {} in etcd: {}", searchUnit.getName(), e.getMessage(), e);
+            throw new Exception("Failed to update search unit in etcd", e);
+        }
     }
     
     @Override
     public void deleteSearchUnit(String unitName) throws Exception {
         log.info("Deleting search unit {} from etcd", unitName);
-        // TODO: etcd.getKVClient().delete(unitPath)
+        
+        try {
+            String unitPath = pathResolver.getSearchUnitConfPath(unitName);
+            ByteSequence keyBytes = ByteSequence.from(unitPath, StandardCharsets.UTF_8);
+            
+            var response = kvClient.delete(keyBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            if (response.getDeleted() > 0) {
+                log.info("Successfully deleted search unit {} from etcd", unitName);
+            } else {
+                log.warn("Search unit {} not found in etcd for deletion", unitName);
+            }
+            
+        } catch (Exception e) {
+            log.error("Failed to delete search unit {} from etcd: {}", unitName, e.getMessage(), e);
+            throw new Exception("Failed to delete search unit from etcd", e);
+        }
     }
     
     // =================================================================
@@ -139,34 +347,118 @@ public class EtcdMetadataStore implements MetadataStore {
     @Override
     public List<String> getAllIndexConfigs() throws Exception {
         log.debug("Getting all index configs from etcd");
-        // TODO: etcd.getKVClient().get() with prefix
-        return List.of();
+        
+        try {
+            String indicesPrefix = pathResolver.getIndicesPrefix();
+            ByteSequence prefixBytes = ByteSequence.from(indicesPrefix, StandardCharsets.UTF_8);
+            
+            GetResponse response = kvClient.get(
+                prefixBytes,
+                GetOption.newBuilder().withPrefix(prefixBytes).build()
+            ).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            List<String> indexConfigs = new ArrayList<>();
+            for (var kv : response.getKvs()) {
+                String indexConfig = kv.getValue().toString(StandardCharsets.UTF_8);
+                indexConfigs.add(indexConfig);
+            }
+            
+            log.debug("Retrieved {} index configs from etcd", indexConfigs.size());
+            return indexConfigs;
+            
+        } catch (Exception e) {
+            log.error("Failed to get all index configs from etcd: {}", e.getMessage(), e);
+            throw new Exception("Failed to retrieve index configs from etcd", e);
+        }
     }
     
     @Override
     public Optional<String> getIndexConfig(String indexName) throws Exception {
         log.debug("Getting index config {} from etcd", indexName);
-        // TODO: etcd.getKVClient().get(indexPath)
-        return Optional.empty();
+        
+        try {
+            String indexPath = pathResolver.getIndexConfPath(indexName);
+            ByteSequence keyBytes = ByteSequence.from(indexPath, StandardCharsets.UTF_8);
+            
+            GetResponse response = kvClient.get(keyBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            if (response.getCount() == 0) {
+                log.debug("Index config {} not found in etcd", indexName);
+                return Optional.empty();
+            }
+            
+            String indexConfig = response.getKvs().get(0).getValue().toString(StandardCharsets.UTF_8);
+            
+            log.debug("Retrieved index config {} from etcd", indexName);
+            return Optional.of(indexConfig);
+            
+        } catch (Exception e) {
+            log.error("Failed to get index config {} from etcd: {}", indexName, e.getMessage(), e);
+            throw new Exception("Failed to retrieve index config from etcd", e);
+        }
     }
     
     @Override
     public String createIndexConfig(String indexName, String indexConfig) throws Exception {
         log.info("Creating index config {} in etcd", indexName);
-        // TODO: etcd.getKVClient().put(indexPath, indexConfig)
-        return indexName;
+        
+        try {
+            String indexPath = pathResolver.getIndexConfPath(indexName);
+            
+            ByteSequence keyBytes = ByteSequence.from(indexPath, StandardCharsets.UTF_8);
+            ByteSequence valueBytes = ByteSequence.from(indexConfig, StandardCharsets.UTF_8);
+            
+            kvClient.put(keyBytes, valueBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            log.info("Successfully created index config {} in etcd", indexName);
+            return indexName;
+            
+        } catch (Exception e) {
+            log.error("Failed to create index config {} in etcd: {}", indexName, e.getMessage(), e);
+            throw new Exception("Failed to create index config in etcd", e);
+        }
     }
     
     @Override
     public void updateIndexConfig(String indexName, String indexConfig) throws Exception {
         log.debug("Updating index config {} in etcd", indexName);
-        // TODO: etcd.getKVClient().put(indexPath, indexConfig)
+        
+        try {
+            String indexPath = pathResolver.getIndexConfPath(indexName);
+            
+            ByteSequence keyBytes = ByteSequence.from(indexPath, StandardCharsets.UTF_8);
+            ByteSequence valueBytes = ByteSequence.from(indexConfig, StandardCharsets.UTF_8);
+            
+            kvClient.put(keyBytes, valueBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            log.debug("Successfully updated index config {} in etcd", indexName);
+            
+        } catch (Exception e) {
+            log.error("Failed to update index config {} in etcd: {}", indexName, e.getMessage(), e);
+            throw new Exception("Failed to update index config in etcd", e);
+        }
     }
     
     @Override
     public void deleteIndexConfig(String indexName) throws Exception {
         log.info("Deleting index config {} from etcd", indexName);
-        // TODO: etcd.getKVClient().delete(indexPath)
+        
+        try {
+            String indexPath = pathResolver.getIndexConfPath(indexName);
+            ByteSequence keyBytes = ByteSequence.from(indexPath, StandardCharsets.UTF_8);
+            
+            var response = kvClient.delete(keyBytes).get(ETCD_OPERATION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            
+            if (response.getDeleted() > 0) {
+                log.info("Successfully deleted index config {} from etcd", indexName);
+            } else {
+                log.warn("Index config {} not found in etcd for deletion", indexName);
+            }
+            
+        } catch (Exception e) {
+            log.error("Failed to delete index config {} from etcd: {}", indexName, e.getMessage(), e);
+            throw new Exception("Failed to delete index config from etcd", e);
+        }
     }
     
     // =================================================================
@@ -181,11 +473,27 @@ public class EtcdMetadataStore implements MetadataStore {
     @Override
     public void close() throws Exception {
         log.info("Closing etcd metadata store");
-        // TODO: etcdClient.close()
+        
+        try {
+            if (etcdClient != null) {
+                etcdClient.close();
+                log.info("etcd client closed successfully");
+            }
+        } catch (Exception e) {
+            log.error("Error closing etcd client: {}", e.getMessage(), e);
+            throw new Exception("Failed to close etcd client", e);
+        }
     }
     
     @Override
     public String getClusterName() {
         return clusterName;
+    }
+    
+    /**
+     * Get the path resolver for external use
+     */
+    public EtcdPathResolver getPathResolver() {
+        return pathResolver;
     }
 }

--- a/src/main/java/io/clustercontroller/store/EtcdPathResolver.java
+++ b/src/main/java/io/clustercontroller/store/EtcdPathResolver.java
@@ -1,0 +1,200 @@
+package io.clustercontroller.store;
+
+import java.nio.file.Paths;
+
+import static io.clustercontroller.config.Constants.*;
+
+/**
+ * Centralized etcd path resolver for all metadata keys.
+ * Provides consistent path structure for tasks, search units, indices, and other cluster metadata.
+ */
+public class EtcdPathResolver {
+    
+    private static final String PATH_DELIMITER = "/";
+    
+    private final String clusterName;
+    
+    public EtcdPathResolver(String clusterName) {
+        this.clusterName = clusterName;
+    }
+    
+    // =================================================================
+    // CONTROLLER TASKS PATHS
+    // =================================================================
+    
+    /**
+     * Get prefix for all controller tasks
+     * Pattern: /<cluster-name>/ctl-tasks/
+     */
+    public String getControllerTasksPrefix() {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_CTL_TASKS).toString() + PATH_DELIMITER;
+    }
+    
+    /**
+     * Get path for specific controller task
+     * Pattern: /<cluster-name>/ctl-tasks/<task-name>
+     */
+    public String getControllerTaskPath(String taskName) {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_CTL_TASKS, taskName).toString();
+    }
+    
+    // =================================================================
+    // SEARCH UNIT PATHS
+    // =================================================================
+    
+    /**
+     * Get prefix for all search units
+     * Pattern: /<cluster-name>/search-units/
+     */
+    public String getSearchUnitsPrefix() {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_SEARCH_UNITS).toString() + PATH_DELIMITER;
+    }
+    
+    /**
+     * Get search unit configuration path
+     * Pattern: /<cluster-name>/search-units/<unit-name>/conf
+     */
+    public String getSearchUnitConfPath(String unitName) {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_SEARCH_UNITS, unitName, SUFFIX_CONF).toString();
+    }
+    
+    /**
+     * Get search unit goal state path
+     * Pattern: /<cluster-name>/search-units/<unit-name>/goal-state
+     */
+    public String getSearchUnitGoalStatePath(String unitName) {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_SEARCH_UNITS, unitName, SUFFIX_GOAL_STATE).toString();
+    }
+    
+    /**
+     * Get search unit actual state path
+     * Pattern: /<cluster-name>/search-units/<unit-name>/actual-state
+     */
+    public String getSearchUnitActualStatePath(String unitName) {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_SEARCH_UNITS, unitName, SUFFIX_ACTUAL_STATE).toString();
+    }
+    
+    /**
+     * Get prefix for search unit actual states
+     * Pattern: /<cluster-name>/search-units/[unit-name]/actual-state
+     */
+    public String getSearchUnitActualStatesPrefix() {
+        return getSearchUnitsPrefix();
+    }
+    
+    // =================================================================
+    // INDEX PATHS
+    // =================================================================
+    
+    /**
+     * Get prefix for all indices
+     * Pattern: /<cluster-name>/indices/
+     */
+    public String getIndicesPrefix() {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES).toString() + PATH_DELIMITER;
+    }
+    
+    /**
+     * Get index configuration path
+     * Pattern: /<cluster-name>/indices/<index-name>/conf
+     */
+    public String getIndexConfPath(String indexName) {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES, indexName, SUFFIX_CONF).toString();
+    }
+    
+    /**
+     * Get index mappings path
+     * Pattern: /<cluster-name>/indices/<index-name>/mappings
+     */
+    public String getIndexMappingsPath(String indexName) {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES, indexName, SUFFIX_MAPPINGS).toString();
+    }
+    
+    /**
+     * Get index settings path
+     * Pattern: /<cluster-name>/indices/<index-name>/settings
+     */
+    public String getIndexSettingsPath(String indexName) {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES, indexName, SUFFIX_SETTINGS).toString();
+    }
+    
+    // =================================================================
+    // SHARD ALLOCATION PATHS
+    // =================================================================
+    
+    /**
+     * Get shard planned allocation path
+     * Pattern: /<cluster-name>/indices/<index-name>/shard/<shard-id>/planned-allocation
+     */
+    public String getShardPlannedAllocationPath(String indexName, String shardId) {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES, indexName, PATH_SHARD, shardId, SUFFIX_PLANNED_ALLOCATION).toString();
+    }
+    
+    /**
+     * Get shard actual allocation path
+     * Pattern: /<cluster-name>/indices/<index-name>/shard/<shard-id>/actual-allocation
+     */
+    public String getShardActualAllocationPath(String indexName, String shardId) {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES, indexName, PATH_SHARD, shardId, SUFFIX_ACTUAL_ALLOCATION).toString();
+    }
+    
+    // =================================================================
+    // COORDINATOR PATHS
+    // =================================================================
+    
+    /**
+     * Get prefix for all coordinators
+     * Pattern: /<cluster-name>/coordinators/
+     */
+    public String getCoordinatorsPrefix() {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_COORDINATORS).toString() + PATH_DELIMITER;
+    }
+    
+    /**
+     * Get shared coordinator goal state path (common for all coordinators)
+     * Pattern: /<cluster-name>/coordinators/goal-state
+     */
+    public String getCoordinatorGoalStatePath() {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_COORDINATORS, SUFFIX_GOAL_STATE).toString();
+    }
+    
+    /**
+     * Get coordinator actual state path (per-coordinator reporting)
+     * Pattern: /<cluster-name>/coordinators/<coordinator-name>/actual-state
+     */
+    public String getCoordinatorActualStatePath(String coordinatorName) {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_COORDINATORS, coordinatorName, SUFFIX_ACTUAL_STATE).toString();
+    }
+    
+    
+    // =================================================================
+    // LEADER ELECTION PATHS
+    // =================================================================
+    
+    /**
+     * Get leader election path
+     * Pattern: /<cluster-name>/leader-election
+     */
+    public String getLeaderElectionPath() {
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_LEADER_ELECTION).toString();
+    }
+    
+    // =================================================================
+    // UTILITY METHODS
+    // =================================================================
+    
+    /**
+     * Get cluster root path
+     * Pattern: /<cluster-name>
+     */
+    public String getClusterRoot() {
+        return Paths.get(PATH_DELIMITER, clusterName).toString();
+    }
+    
+    /**
+     * Get cluster name
+     */
+    public String getClusterName() {
+        return clusterName;
+    }
+}

--- a/src/main/java/io/clustercontroller/store/EtcdPathResolver.java
+++ b/src/main/java/io/clustercontroller/store/EtcdPathResolver.java
@@ -24,10 +24,10 @@ public class EtcdPathResolver {
     
     /**
      * Get prefix for all controller tasks
-     * Pattern: /<cluster-name>/ctl-tasks/
+     * Pattern: /<cluster-name>/ctl-tasks
      */
     public String getControllerTasksPrefix() {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_CTL_TASKS).toString() + PATH_DELIMITER;
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_CTL_TASKS).toString();
     }
     
     /**
@@ -35,7 +35,7 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/ctl-tasks/<task-name>
      */
     public String getControllerTaskPath(String taskName) {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_CTL_TASKS, taskName).toString();
+        return Paths.get(getControllerTasksPrefix(), taskName).toString();
     }
     
     // =================================================================
@@ -44,10 +44,10 @@ public class EtcdPathResolver {
     
     /**
      * Get prefix for all search units
-     * Pattern: /<cluster-name>/search-units/
+     * Pattern: /<cluster-name>/search-units
      */
     public String getSearchUnitsPrefix() {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_SEARCH_UNITS).toString() + PATH_DELIMITER;
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_SEARCH_UNITS).toString();
     }
     
     /**
@@ -55,7 +55,7 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/search-units/<unit-name>/conf
      */
     public String getSearchUnitConfPath(String unitName) {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_SEARCH_UNITS, unitName, SUFFIX_CONF).toString();
+        return Paths.get(getSearchUnitsPrefix(), unitName, SUFFIX_CONF).toString();
     }
     
     /**
@@ -63,7 +63,7 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/search-units/<unit-name>/goal-state
      */
     public String getSearchUnitGoalStatePath(String unitName) {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_SEARCH_UNITS, unitName, SUFFIX_GOAL_STATE).toString();
+        return Paths.get(getSearchUnitsPrefix(), unitName, SUFFIX_GOAL_STATE).toString();
     }
     
     /**
@@ -71,16 +71,9 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/search-units/<unit-name>/actual-state
      */
     public String getSearchUnitActualStatePath(String unitName) {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_SEARCH_UNITS, unitName, SUFFIX_ACTUAL_STATE).toString();
+        return Paths.get(getSearchUnitsPrefix(), unitName, SUFFIX_ACTUAL_STATE).toString();
     }
     
-    /**
-     * Get prefix for search unit actual states
-     * Pattern: /<cluster-name>/search-units/[unit-name]/actual-state
-     */
-    public String getSearchUnitActualStatesPrefix() {
-        return getSearchUnitsPrefix();
-    }
     
     // =================================================================
     // INDEX PATHS
@@ -88,10 +81,10 @@ public class EtcdPathResolver {
     
     /**
      * Get prefix for all indices
-     * Pattern: /<cluster-name>/indices/
+     * Pattern: /<cluster-name>/indices
      */
     public String getIndicesPrefix() {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES).toString() + PATH_DELIMITER;
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES).toString();
     }
     
     /**
@@ -99,7 +92,7 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/indices/<index-name>/conf
      */
     public String getIndexConfPath(String indexName) {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES, indexName, SUFFIX_CONF).toString();
+        return Paths.get(getIndicesPrefix(), indexName, SUFFIX_CONF).toString();
     }
     
     /**
@@ -107,7 +100,7 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/indices/<index-name>/mappings
      */
     public String getIndexMappingsPath(String indexName) {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES, indexName, SUFFIX_MAPPINGS).toString();
+        return Paths.get(getIndicesPrefix(), indexName, SUFFIX_MAPPINGS).toString();
     }
     
     /**
@@ -115,7 +108,7 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/indices/<index-name>/settings
      */
     public String getIndexSettingsPath(String indexName) {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES, indexName, SUFFIX_SETTINGS).toString();
+        return Paths.get(getIndicesPrefix(), indexName, SUFFIX_SETTINGS).toString();
     }
     
     // =================================================================
@@ -127,7 +120,7 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/indices/<index-name>/shard/<shard-id>/planned-allocation
      */
     public String getShardPlannedAllocationPath(String indexName, String shardId) {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES, indexName, PATH_SHARD, shardId, SUFFIX_PLANNED_ALLOCATION).toString();
+        return Paths.get(getIndicesPrefix(), indexName, PATH_SHARD, shardId, SUFFIX_PLANNED_ALLOCATION).toString();
     }
     
     /**
@@ -135,7 +128,7 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/indices/<index-name>/shard/<shard-id>/actual-allocation
      */
     public String getShardActualAllocationPath(String indexName, String shardId) {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_INDICES, indexName, PATH_SHARD, shardId, SUFFIX_ACTUAL_ALLOCATION).toString();
+        return Paths.get(getIndicesPrefix(), indexName, PATH_SHARD, shardId, SUFFIX_ACTUAL_ALLOCATION).toString();
     }
     
     // =================================================================
@@ -144,10 +137,10 @@ public class EtcdPathResolver {
     
     /**
      * Get prefix for all coordinators
-     * Pattern: /<cluster-name>/coordinators/
+     * Pattern: /<cluster-name>/coordinators
      */
     public String getCoordinatorsPrefix() {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_COORDINATORS).toString() + PATH_DELIMITER;
+        return Paths.get(PATH_DELIMITER, clusterName, PATH_COORDINATORS).toString();
     }
     
     /**
@@ -155,7 +148,7 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/coordinators/goal-state
      */
     public String getCoordinatorGoalStatePath() {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_COORDINATORS, SUFFIX_GOAL_STATE).toString();
+        return Paths.get(getCoordinatorsPrefix(), SUFFIX_GOAL_STATE).toString();
     }
     
     /**
@@ -163,7 +156,7 @@ public class EtcdPathResolver {
      * Pattern: /<cluster-name>/coordinators/<coordinator-name>/actual-state
      */
     public String getCoordinatorActualStatePath(String coordinatorName) {
-        return Paths.get(PATH_DELIMITER, clusterName, PATH_COORDINATORS, coordinatorName, SUFFIX_ACTUAL_STATE).toString();
+        return Paths.get(getCoordinatorsPrefix(), coordinatorName, SUFFIX_ACTUAL_STATE).toString();
     }
     
     

--- a/src/test/java/io/clustercontroller/store/EtcdMetadataStoreTest.java
+++ b/src/test/java/io/clustercontroller/store/EtcdMetadataStoreTest.java
@@ -1,104 +1,462 @@
 package io.clustercontroller.store;
 
-import io.clustercontroller.models.TaskMetadata;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.clustercontroller.models.SearchUnit;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import io.clustercontroller.models.TaskMetadata;
+import io.etcd.jetcd.*;
+import io.etcd.jetcd.kv.DeleteResponse;
+import io.etcd.jetcd.kv.GetResponse;
+import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.kv.PutResponse;
+import io.etcd.jetcd.options.GetOption;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 
-import static io.clustercontroller.config.Constants.*;
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for EtcdMetadataStore.
  */
-class EtcdMetadataStoreTest {
-    
-    private EtcdMetadataStore metadataStore;
-    
+public class EtcdMetadataStoreTest {
+
+    private static final String CLUSTER = "test-cluster";
+    private static final String[] ENDPOINTS = new String[]{"http://localhost:2379"};
+
+    private MockedStatic<Client> clientStaticMock;
+    private Client mockEtcdClient;
+    private KV mockKv;
+
     @BeforeEach
-    void setUp() throws Exception {
-        String[] etcdEndpoints = {"localhost:2379"};
-        metadataStore = EtcdMetadataStore.getInstance("test-cluster", etcdEndpoints);
+    public void setUp() throws Exception {
+        // Static mock for Client.builder()
+        clientStaticMock = Mockito.mockStatic(Client.class);
+
+        // Mock the builder chain Client.builder().endpoints(...).build()
+        ClientBuilder mockBuilder = mock(ClientBuilder.class);
+        clientStaticMock.when(Client::builder).thenReturn(mockBuilder);
+        when(mockBuilder.endpoints(any(String[].class))).thenReturn(mockBuilder);
+
+        // Mock etcd Client and KV
+        mockEtcdClient = mock(Client.class);
+        mockKv = mock(KV.class);
+        when(mockEtcdClient.getKVClient()).thenReturn(mockKv);
+        when(mockBuilder.build()).thenReturn(mockEtcdClient);
+
+        // Ensure singleton is reset before each test
+        resetSingleton();
     }
-    
-    @Test
-    void testSingletonInstance() throws Exception {
-        String[] etcdEndpoints = {"localhost:2379"};
-        EtcdMetadataStore instance1 = EtcdMetadataStore.getInstance("test-cluster", etcdEndpoints);
-        EtcdMetadataStore instance2 = EtcdMetadataStore.getInstance();
-        
-        assertThat(instance1).isSameAs(instance2);
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (clientStaticMock != null) clientStaticMock.close();
+        resetSingleton();
     }
-    
-    @Test
-    void testGetClusterName() {
-        assertThat(metadataStore.getClusterName()).isEqualTo("test-cluster");
+
+    // ------------------------- helpers -------------------------
+
+    private void resetSingleton() throws Exception {
+        Field f = EtcdMetadataStore.class.getDeclaredField("instance");
+        f.setAccessible(true);
+        f.set(null, null);
     }
-    
-    @Test
-    void testGetAllTasksReturnsEmpty() throws Exception {
-        List<TaskMetadata> tasks = metadataStore.getAllTasks();
-        
-        assertThat(tasks).isNotNull();
-        assertThat(tasks).isEmpty();
+
+    private EtcdMetadataStore newStore() throws Exception {
+        return EtcdMetadataStore.getInstance(CLUSTER, ENDPOINTS);
     }
-    
-    @Test
-    void testGetTaskReturnsEmpty() throws Exception {
-        Optional<TaskMetadata> task = metadataStore.getTask("non-existent-task");
-        
-        assertThat(task).isEmpty();
+
+    private GetResponse mockGetResponse(List<KeyValue> kvs) {
+        GetResponse resp = mock(GetResponse.class);
+        when(resp.getKvs()).thenReturn(kvs);
+        when(resp.getCount()).thenReturn((long) kvs.size());
+        return resp;
     }
-    
-    @Test
-    void testCreateTaskReturnsName() throws Exception {
-        TaskMetadata task = new TaskMetadata("test-task", 1);
-        
-        String result = metadataStore.createTask(task);
-        
-        assertThat(result).isEqualTo("test-task");
+
+    private KeyValue mockKv(String valueUtf8) {
+        KeyValue kv = mock(KeyValue.class);
+        ByteSequence val = ByteSequence.from(valueUtf8, StandardCharsets.UTF_8);
+        when(kv.getValue()).thenReturn(val);
+        return kv;
     }
-    
-    @Test
-    void testGetAllSearchUnitsReturnsEmpty() throws Exception {
-        List<SearchUnit> units = metadataStore.getAllSearchUnits();
-        
-        assertThat(units).isNotNull();
-        assertThat(units).isEmpty();
+
+    private PutResponse mockPutResponse() {
+        return mock(PutResponse.class);
     }
-    
-    @Test
-    void testGetSearchUnitReturnsEmpty() throws Exception {
-        Optional<SearchUnit> unit = metadataStore.getSearchUnit("non-existent-unit");
-        
-        assertThat(unit).isEmpty();
+
+    private DeleteResponse mockDeleteResponse(long deleted) {
+        DeleteResponse dr = mock(DeleteResponse.class, withSettings().lenient());
+        doReturn(deleted).when(dr).getDeleted();
+        return dr;
     }
-    
+
+    // ------------------------- singleton tests -------------------------
+
     @Test
-    void testGetAllIndexConfigsReturnsEmpty() throws Exception {
-        List<String> configs = metadataStore.getAllIndexConfigs();
-        
-        assertThat(configs).isNotNull();
-        assertThat(configs).isEmpty();
+    public void testSingletonGetInstance() throws Exception {
+        EtcdMetadataStore s1 = newStore();
+        EtcdMetadataStore s2 = EtcdMetadataStore.getInstance(CLUSTER, ENDPOINTS);
+        assertThat(s1).isSameAs(s2);
+        assertThat(s1.getClusterName()).isEqualTo(CLUSTER);
     }
-    
+
     @Test
-    void testGetIndexConfigReturnsEmpty() throws Exception {
-        Optional<String> config = metadataStore.getIndexConfig("non-existent-index");
-        
-        assertThat(config).isEmpty();
+    public void testGetInstanceNoArgsThrowsWhenUninitialized() {
+        // Not calling newStore()
+        assertThatThrownBy(() -> EtcdMetadataStore.getInstance())
+            .isInstanceOf(IllegalStateException.class);
     }
-    
+
+    // ------------------------- tasks -------------------------
+
     @Test
-    void testCreateIndexConfigReturnsName() throws Exception {
-        String indexName = "test-index";
-        String indexConfig = "{}";
+    public void testGetAllTasksSortedByPriority() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        // Two tasks (priority 5 and 0), expect sorted ascending by priority
+        String tHigh = "{\"name\":\"task-high\",\"priority\":5}";
+        String tTop = "{\"name\":\"task-top\",\"priority\":0}";
+
+        GetResponse resp = mockGetResponse(Arrays.asList(
+                mockKv(tHigh),
+                mockKv(tTop)
+        ));
+
+        when(mockKv.get(any(ByteSequence.class), any(GetOption.class)))
+                .thenReturn(CompletableFuture.completedFuture(resp));
+
+        List<TaskMetadata> tasks = store.getAllTasks();
+
+        assertThat(tasks).hasSize(2);
+        assertThat(tasks.get(0).getName()).isEqualTo("task-top");
+        assertThat(tasks.get(0).getPriority()).isEqualTo(0);
+        assertThat(tasks.get(1).getName()).isEqualTo("task-high");
+        assertThat(tasks.get(1).getPriority()).isEqualTo(5);
+    }
+
+    @Test
+    public void testGetTaskFound() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        String tJson = "{\"name\":\"index-task\",\"priority\":3}";
+        GetResponse resp = mockGetResponse(Collections.singletonList(mockKv(tJson)));
+        when(mockKv.get(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(resp));
+
+        Optional<TaskMetadata> got = store.getTask("index-task");
+        assertThat(got).isPresent();
+        assertThat(got.get().getName()).isEqualTo("index-task");
+        assertThat(got.get().getPriority()).isEqualTo(3);
+    }
+
+    @Test
+    public void testGetTaskNotFound() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        GetResponse resp = mockGetResponse(Collections.emptyList());
+        when(mockKv.get(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(resp));
+
+        Optional<TaskMetadata> got = store.getTask("missing");
+        assertThat(got).isEmpty();
+    }
+
+    @Test
+    public void testCreateTaskWritesJsonAndReturnsName() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        // Replace the store's ObjectMapper with a mock to control JSON
+        ObjectMapper om = mock(ObjectMapper.class);
+        setPrivateField(store, "objectMapper", om);
+
+        TaskMetadata task = mock(TaskMetadata.class);
+        when(task.getName()).thenReturn("cleanup-task");
+        when(om.writeValueAsString(task)).thenReturn("{\"name\":\"cleanup-task\"}");
+
+        when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mockPutResponse()));
+
+        String name = store.createTask(task);
+        assertThat(name).isEqualTo("cleanup-task");
+        verify(mockKv, times(1)).put(any(ByteSequence.class), any(ByteSequence.class));
+    }
+
+    @Test
+    public void testUpdateTaskPutsJson() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        ObjectMapper om = mock(ObjectMapper.class);
+        setPrivateField(store, "objectMapper", om);
+
+        TaskMetadata task = mock(TaskMetadata.class);
+        when(task.getName()).thenReturn("maintenance-task");
+        when(om.writeValueAsString(task)).thenReturn("{\"name\":\"maintenance-task\"}");
+
+        when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mockPutResponse()));
+
+        store.updateTask(task);
+        verify(mockKv, times(1)).put(any(ByteSequence.class), any(ByteSequence.class));
+    }
+
+    @Test
+    public void testDeleteTask() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        // Mock successful delete - we don't need to check the response since method returns void
+        when(mockKv.delete(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mock(DeleteResponse.class)));
+
+        // Call delete method
+        store.deleteTask("old-task");
         
-        String result = metadataStore.createIndexConfig(indexName, indexConfig);
+        // Verify etcd delete was called with correct parameters
+        verify(mockKv, times(1)).delete(any(ByteSequence.class));
+    }
+
+    @Test
+    public void testDeleteTaskWithException() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        // Mock etcd failure
+        when(mockKv.delete(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("etcd connection failed")));
+
+        // Verify exception is propagated
+        assertThatThrownBy(() -> store.deleteTask("failing-task"))
+                .isInstanceOf(Exception.class)
+                .hasMessageContaining("Failed to delete task from etcd");
+    }
+
+    // ------------------------- search units -------------------------
+
+    @Test
+    public void testGetAllSearchUnits() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        String u1 = "{\"name\":\"node1\"}";
+        String u2 = "{\"name\":\"node2\"}";
+
+        GetResponse resp = mockGetResponse(Arrays.asList(
+                mockKv(u1), mockKv(u2)
+        ));
+        when(mockKv.get(any(ByteSequence.class), any(GetOption.class)))
+                .thenReturn(CompletableFuture.completedFuture(resp));
+
+        List<SearchUnit> units = store.getAllSearchUnits();
+        assertThat(units).hasSize(2);
+        assertThat(units.get(0).getName()).isIn("node1", "node2");
+    }
+
+    @Test
+    public void testGetSearchUnitFound() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        String json = "{\"name\":\"node3\"}";
+        GetResponse resp = mockGetResponse(Collections.singletonList(mockKv(json)));
+        when(mockKv.get(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(resp));
+
+        Optional<SearchUnit> got = store.getSearchUnit("node3");
+        assertThat(got).isPresent();
+        assertThat(got.get().getName()).isEqualTo("node3");
+    }
+
+    @Test
+    public void testGetSearchUnitNotFound() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        GetResponse resp = mockGetResponse(Collections.emptyList());
+        when(mockKv.get(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(resp));
+
+        Optional<SearchUnit> got = store.getSearchUnit("missing");
+        assertThat(got).isEmpty();
+    }
+
+    @Test
+    public void testUpsertSearchUnit() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        ObjectMapper om = mock(ObjectMapper.class);
+        setPrivateField(store, "objectMapper", om);
+
+        SearchUnit unit = mock(SearchUnit.class);
+        when(om.writeValueAsString(unit)).thenReturn("{\"name\":\"node4\"}");
+
+        when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mockPutResponse()));
+
+        store.upsertSearchUnit("node4", unit);
+        verify(mockKv).put(any(ByteSequence.class), any(ByteSequence.class));
+    }
+
+    @Test
+    public void testUpdateSearchUnit() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        ObjectMapper om = mock(ObjectMapper.class);
+        setPrivateField(store, "objectMapper", om);
+
+        SearchUnit unit = mock(SearchUnit.class);
+        when(unit.getName()).thenReturn("node5");
+        when(om.writeValueAsString(unit)).thenReturn("{\"name\":\"node5\"}");
+
+        when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mockPutResponse()));
+
+        store.updateSearchUnit(unit);
+        verify(mockKv).put(any(ByteSequence.class), any(ByteSequence.class));
+    }
+
+    @Test
+    public void testDeleteSearchUnit() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        // Mock successful delete - we don't need to check the response since method returns void
+        when(mockKv.delete(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mock(DeleteResponse.class)));
+
+        // Call delete method
+        store.deleteSearchUnit("node6");
         
-        assertThat(result).isEqualTo(indexName);
+        // Verify etcd delete was called with correct parameters
+        verify(mockKv).delete(any(ByteSequence.class));
+    }
+
+    @Test
+    public void testDeleteSearchUnitWithException() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        // Mock etcd failure
+        when(mockKv.delete(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("etcd timeout")));
+
+        // Verify exception is propagated
+        assertThatThrownBy(() -> store.deleteSearchUnit("node7"))
+                .isInstanceOf(Exception.class)
+                .hasMessageContaining("Failed to delete search unit from etcd");
+    }
+
+    // ------------------------- index configs -------------------------
+
+    @Test
+    public void testGetAllIndexConfigs() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        GetResponse resp = mockGetResponse(Arrays.asList(
+                mockKv("{\"settings\":{\"refresh_interval\":\"1s\"}}"),
+                mockKv("{\"settings\":{\"number_of_shards\":3}}")
+        ));
+        when(mockKv.get(any(ByteSequence.class), any(GetOption.class)))
+                .thenReturn(CompletableFuture.completedFuture(resp));
+
+        List<String> configs = store.getAllIndexConfigs();
+        assertThat(configs).hasSize(2);
+        assertThat(configs.get(0)).contains("settings");
+    }
+
+    @Test
+    public void testGetIndexConfigFound() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        String cfg = "{\"analysis\":{\"analyzer\":{\"std\":\"standard\"}}}";
+        GetResponse resp = mockGetResponse(Collections.singletonList(mockKv(cfg)));
+        when(mockKv.get(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(resp));
+
+        Optional<String> got = store.getIndexConfig("user-index");
+        assertThat(got).isPresent();
+        assertThat(got.get()).contains("analysis");
+    }
+
+    @Test
+    public void testGetIndexConfigNotFound() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        GetResponse resp = mockGetResponse(Collections.emptyList());
+        when(mockKv.get(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(resp));
+
+        Optional<String> got = store.getIndexConfig("missing");
+        assertThat(got).isEmpty();
+    }
+
+    @Test
+    public void testCreateIndexConfig() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mockPutResponse()));
+
+        String name = store.createIndexConfig("test-index", "{\"x\":1}");
+        assertThat(name).isEqualTo("test-index");
+        verify(mockKv).put(any(ByteSequence.class), any(ByteSequence.class));
+    }
+
+    @Test
+    public void testUpdateIndexConfig() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mockPutResponse()));
+
+        store.updateIndexConfig("user-index", "{\"y\":2}");
+        verify(mockKv).put(any(ByteSequence.class), any(ByteSequence.class));
+    }
+
+    @Test
+    public void testDeleteIndexConfig() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        // Mock successful delete - we don't need to check the response since method returns void
+        when(mockKv.delete(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mock(DeleteResponse.class)));
+
+        // Call delete method
+        store.deleteIndexConfig("old-index");
+        
+        // Verify etcd delete was called with correct parameters
+        verify(mockKv).delete(any(ByteSequence.class));
+    }
+
+    @Test
+    public void testDeleteIndexConfigWithException() throws Exception {
+        EtcdMetadataStore store = newStore();
+
+        // Mock etcd failure
+        when(mockKv.delete(any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("etcd network error")));
+
+        // Verify exception is propagated
+        assertThatThrownBy(() -> store.deleteIndexConfig("test-index"))
+                .isInstanceOf(Exception.class)
+                .hasMessageContaining("Failed to delete index config from etcd");
+    }
+
+    // ------------------------- lifecycle -------------------------
+
+    @Test
+    public void testCloseClosesEtcdClient() throws Exception {
+        EtcdMetadataStore store = newStore();
+        store.close();
+        verify(mockEtcdClient, times(1)).close();
+    }
+
+    // ------------------------- reflection util -------------------------
+
+    private static void setPrivateField(Object target, String fieldName, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
     }
 }

--- a/src/test/java/io/clustercontroller/store/EtcdPathResolverTest.java
+++ b/src/test/java/io/clustercontroller/store/EtcdPathResolverTest.java
@@ -1,0 +1,180 @@
+package io.clustercontroller.store;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Tests for EtcdPathResolver.
+ */
+class EtcdPathResolverTest {
+    
+    private EtcdPathResolver pathResolver;
+    private final String testClusterName = "test-cluster";
+    
+    @BeforeEach
+    void setUp() {
+        pathResolver = new EtcdPathResolver(testClusterName);
+    }
+    
+    @Test
+    void testGetClusterName() {
+        assertThat(pathResolver.getClusterName()).isEqualTo(testClusterName);
+    }
+    
+    @Test
+    void testGetClusterRoot() {
+        String result = pathResolver.getClusterRoot();
+        assertThat(result).isEqualTo("/test-cluster");
+    }
+    
+    // =================================================================
+    // CONTROLLER TASKS PATHS TESTS
+    // =================================================================
+    
+    @Test
+    void testGetControllerTasksPrefix() {
+        String result = pathResolver.getControllerTasksPrefix();
+        assertThat(result).isEqualTo("/test-cluster/ctl-tasks/");
+    }
+    
+    @Test
+    void testGetControllerTaskPath() {
+        String result = pathResolver.getControllerTaskPath("create-index-task");
+        assertThat(result).isEqualTo("/test-cluster/ctl-tasks/create-index-task");
+    }
+    
+    // =================================================================
+    // SEARCH UNIT PATHS TESTS
+    // =================================================================
+    
+    @Test
+    void testGetSearchUnitsPrefix() {
+        String result = pathResolver.getSearchUnitsPrefix();
+        assertThat(result).isEqualTo("/test-cluster/search-units/");
+    }
+    
+    @Test
+    void testGetSearchUnitConfPath() {
+        String result = pathResolver.getSearchUnitConfPath("unit-1");
+        assertThat(result).isEqualTo("/test-cluster/search-units/unit-1/conf");
+    }
+    
+    @Test
+    void testGetSearchUnitGoalStatePath() {
+        String result = pathResolver.getSearchUnitGoalStatePath("unit-1");
+        assertThat(result).isEqualTo("/test-cluster/search-units/unit-1/goal-state");
+    }
+    
+    @Test
+    void testGetSearchUnitActualStatePath() {
+        String result = pathResolver.getSearchUnitActualStatePath("unit-1");
+        assertThat(result).isEqualTo("/test-cluster/search-units/unit-1/actual-state");
+    }
+    
+    @Test
+    void testGetSearchUnitActualStatesPrefix() {
+        String result = pathResolver.getSearchUnitActualStatesPrefix();
+        assertThat(result).isEqualTo("/test-cluster/search-units/");
+    }
+    
+    // =================================================================
+    // INDEX PATHS TESTS
+    // =================================================================
+    
+    @Test
+    void testGetIndicesPrefix() {
+        String result = pathResolver.getIndicesPrefix();
+        assertThat(result).isEqualTo("/test-cluster/indices/");
+    }
+    
+    @Test
+    void testGetIndexConfPath() {
+        String result = pathResolver.getIndexConfPath("user-index");
+        assertThat(result).isEqualTo("/test-cluster/indices/user-index/conf");
+    }
+    
+    @Test
+    void testGetIndexMappingsPath() {
+        String result = pathResolver.getIndexMappingsPath("user-index");
+        assertThat(result).isEqualTo("/test-cluster/indices/user-index/mappings");
+    }
+    
+    @Test
+    void testGetIndexSettingsPath() {
+        String result = pathResolver.getIndexSettingsPath("user-index");
+        assertThat(result).isEqualTo("/test-cluster/indices/user-index/settings");
+    }
+    
+    // =================================================================
+    // SHARD ALLOCATION PATHS TESTS
+    // =================================================================
+    
+    @Test
+    void testGetShardPlannedAllocationPath() {
+        String result = pathResolver.getShardPlannedAllocationPath("user-index", "0");
+        assertThat(result).isEqualTo("/test-cluster/indices/user-index/shard/0/planned-allocation");
+    }
+    
+    @Test
+    void testGetShardActualAllocationPath() {
+        String result = pathResolver.getShardActualAllocationPath("user-index", "0");
+        assertThat(result).isEqualTo("/test-cluster/indices/user-index/shard/0/actual-allocation");
+    }
+    
+    // =================================================================
+    // COORDINATOR PATHS TESTS
+    // =================================================================
+    
+    @Test
+    void testGetCoordinatorsPrefix() {
+        String result = pathResolver.getCoordinatorsPrefix();
+        assertThat(result).isEqualTo("/test-cluster/coordinators/");
+    }
+    
+    @Test
+    void testGetCoordinatorGoalStatePath() {
+        String result = pathResolver.getCoordinatorGoalStatePath();
+        assertThat(result).isEqualTo("/test-cluster/coordinators/goal-state");
+    }
+    
+    @Test
+    void testGetCoordinatorActualStatePath() {
+        String result = pathResolver.getCoordinatorActualStatePath("coord-1");
+        assertThat(result).isEqualTo("/test-cluster/coordinators/coord-1/actual-state");
+    }
+    
+    // =================================================================
+    // LEADER ELECTION PATHS TESTS
+    // =================================================================
+    
+    @Test
+    void testGetLeaderElectionPath() {
+        String result = pathResolver.getLeaderElectionPath();
+        assertThat(result).isEqualTo("/test-cluster/leader-election");
+    }
+    
+    // =================================================================
+    // EDGE CASES TESTS
+    // =================================================================
+    
+    @Test
+    void testPathsWithSpecialCharacters() {
+        String result = pathResolver.getControllerTaskPath("task-with-dashes_and_underscores");
+        assertThat(result).isEqualTo("/test-cluster/ctl-tasks/task-with-dashes_and_underscores");
+    }
+    
+    @Test
+    void testPathsWithNumbers() {
+        String result = pathResolver.getSearchUnitConfPath("unit-123");
+        assertThat(result).isEqualTo("/test-cluster/search-units/unit-123/conf");
+    }
+    
+    @Test
+    void testClusterNameWithSpecialCharacters() {
+        EtcdPathResolver specialResolver = new EtcdPathResolver("cluster-with-dashes");
+        String result = specialResolver.getControllerTasksPrefix();
+        assertThat(result).isEqualTo("/cluster-with-dashes/ctl-tasks/");
+    }
+}

--- a/src/test/java/io/clustercontroller/store/EtcdPathResolverTest.java
+++ b/src/test/java/io/clustercontroller/store/EtcdPathResolverTest.java
@@ -36,7 +36,7 @@ class EtcdPathResolverTest {
     @Test
     void testGetControllerTasksPrefix() {
         String result = pathResolver.getControllerTasksPrefix();
-        assertThat(result).isEqualTo("/test-cluster/ctl-tasks/");
+        assertThat(result).isEqualTo("/test-cluster/ctl-tasks");
     }
     
     @Test
@@ -52,7 +52,7 @@ class EtcdPathResolverTest {
     @Test
     void testGetSearchUnitsPrefix() {
         String result = pathResolver.getSearchUnitsPrefix();
-        assertThat(result).isEqualTo("/test-cluster/search-units/");
+        assertThat(result).isEqualTo("/test-cluster/search-units");
     }
     
     @Test
@@ -73,11 +73,6 @@ class EtcdPathResolverTest {
         assertThat(result).isEqualTo("/test-cluster/search-units/unit-1/actual-state");
     }
     
-    @Test
-    void testGetSearchUnitActualStatesPrefix() {
-        String result = pathResolver.getSearchUnitActualStatesPrefix();
-        assertThat(result).isEqualTo("/test-cluster/search-units/");
-    }
     
     // =================================================================
     // INDEX PATHS TESTS
@@ -86,7 +81,7 @@ class EtcdPathResolverTest {
     @Test
     void testGetIndicesPrefix() {
         String result = pathResolver.getIndicesPrefix();
-        assertThat(result).isEqualTo("/test-cluster/indices/");
+        assertThat(result).isEqualTo("/test-cluster/indices");
     }
     
     @Test
@@ -130,7 +125,7 @@ class EtcdPathResolverTest {
     @Test
     void testGetCoordinatorsPrefix() {
         String result = pathResolver.getCoordinatorsPrefix();
-        assertThat(result).isEqualTo("/test-cluster/coordinators/");
+        assertThat(result).isEqualTo("/test-cluster/coordinators");
     }
     
     @Test
@@ -175,6 +170,6 @@ class EtcdPathResolverTest {
     void testClusterNameWithSpecialCharacters() {
         EtcdPathResolver specialResolver = new EtcdPathResolver("cluster-with-dashes");
         String result = specialResolver.getControllerTasksPrefix();
-        assertThat(result).isEqualTo("/cluster-with-dashes/ctl-tasks/");
+        assertThat(result).isEqualTo("/cluster-with-dashes/ctl-tasks");
     }
 }


### PR DESCRIPTION
This PR establishes the core metadata infrastructure for cluster state management. The different controller modules will leverage this to interact with etcd

- EtcdMetadataStore: CRUD operations for tasks, search units, and index configs
- EtcdPathResolver: Centralized path construction for etcd

