### PR TITLE
Discovery - prune nodes based on actual state ts

### DIFF
--- a/src/main/java/io/clustercontroller/config/Constants.java
+++ b/src/main/java/io/clustercontroller/config/Constants.java
@@ -55,6 +55,9 @@ public final class Constants {
     public static final int HEALTH_CHECK_MEMORY_THRESHOLD_PERCENT = 90;
     public static final long HEALTH_CHECK_DISK_THRESHOLD_MB = 1024;
     
+    // Discovery cleanup thresholds
+    public static final long STALE_SEARCH_UNIT_TIMEOUT_MINUTES = 10L;
+    
     // Admin state values
     public static final String ADMIN_STATE_NORMAL = "NORMAL";
     public static final String ADMIN_STATE_DRAIN = "DRAIN";

--- a/src/test/java/io/clustercontroller/discovery/DiscoveryTest.java
+++ b/src/test/java/io/clustercontroller/discovery/DiscoveryTest.java
@@ -51,7 +51,7 @@ class DiscoveryTest {
         
         // Then
         verify(metadataStore).getAllSearchUnitActualStates();
-        verify(metadataStore).getAllSearchUnits();
+        verify(metadataStore, times(2)).getAllSearchUnits(); // Called by cleanup + processing
         verify(metadataStore, times(3)).getSearchUnit(anyString()); // 3 units
         verify(metadataStore, times(3)).upsertSearchUnit(anyString(), any(SearchUnit.class));
     }
@@ -89,7 +89,7 @@ class DiscoveryTest {
         assertThatCode(() -> discovery.discoverSearchUnits()).doesNotThrowAnyException();
         
         verify(metadataStore).getAllSearchUnitActualStates();
-        verify(metadataStore).getAllSearchUnits();
+        verify(metadataStore, times(2)).getAllSearchUnits(); // Called by cleanup + processing
     }
     
     // =================================================================


### PR DESCRIPTION
Clean up nodes in discovery task if the last timestamp in actual state is > 10 mins old. 

In shard allocation, we plan to also have a  node selector component to look at heartbeat/metrics and select nodes based on some criteria, like last heartbeat and metrics. 