### PR TITLE
Implement AllocationDecider framework for nodes selection for Shard Allocation Planner

### DIFF
--- a/src/main/java/io/clustercontroller/allocation/AllocationDecisionEngine.java
+++ b/src/main/java/io/clustercontroller/allocation/AllocationDecisionEngine.java
@@ -1,0 +1,102 @@
+package io.clustercontroller.allocation;
+
+import io.clustercontroller.allocation.deciders.*;
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Allocation decision engine that chains multiple AllocationDeciders.
+ * 
+ * Evaluates all enabled deciders and returns nodes that pass all checks.
+ * Callers must explicitly enable the deciders they want to use.
+ */
+@Slf4j
+public class AllocationDecisionEngine {
+    
+    private final Map<Class<? extends AllocationDecider>, AllocationDecider> availableDeciders;
+    
+    /**
+     * List of currently enabled deciders - populated by calling enableDecider().
+     * Callers must explicitly enable the deciders they want to use.
+     * 
+     * TODO: Make decider configuration externally configurable via properties
+     */
+    private final List<AllocationDecider> enabledDeciders;
+    
+    public AllocationDecisionEngine() {
+        this.availableDeciders = new HashMap<>();
+        this.enabledDeciders = new ArrayList<>();
+        
+        // Register all available deciders
+        registerDecider(AllNodesDecider.class, new AllNodesDecider());
+        registerDecider(HealthDecider.class, new HealthDecider());
+        registerDecider(RoleDecider.class, new RoleDecider());
+        registerDecider(ShardPoolDecider.class, new ShardPoolDecider());
+    }
+    
+    /**
+     * Get available nodes for allocation by applying all enabled deciders.
+     */
+    public List<SearchUnit> getAvailableNodesForAllocation(String shardId, String indexName, 
+                                                          List<SearchUnit> candidateNodes, NodeRole targetRole) {
+        List<SearchUnit> selectedNodes = new ArrayList<>();
+        
+        // If no deciders enabled, return empty list
+        if (enabledDeciders.isEmpty()) {
+            return selectedNodes; // Empty list
+        }
+        
+        for (SearchUnit node : candidateNodes) {
+            Decision finalDecision = Decision.YES;
+            
+            for (AllocationDecider decider : enabledDeciders) {
+                if (!decider.isEnabled()) continue;
+                
+                Decision deciderResult = decider.canAllocate(shardId, node, indexName, targetRole);
+                finalDecision = finalDecision.merge(deciderResult);
+                
+                if (finalDecision == Decision.NO) break;
+            }
+            
+            if (finalDecision == Decision.YES) {
+                selectedNodes.add(node);
+            }
+        }
+        
+        return selectedNodes;
+    }
+    
+    /**
+     * Enable a decider.
+     */
+    public void enableDecider(Class<? extends AllocationDecider> deciderClass) {
+        AllocationDecider decider = availableDeciders.get(deciderClass);
+        if (decider != null && !enabledDeciders.contains(decider)) {
+            decider.setEnabled(true);
+            enabledDeciders.add(decider);
+        }
+    }
+    
+    /**
+     * Disable a decider.
+     */
+    public void disableDecider(Class<? extends AllocationDecider> deciderClass) {
+        AllocationDecider decider = availableDeciders.get(deciderClass);
+        if (decider != null) {
+            decider.setEnabled(false);
+            enabledDeciders.remove(decider);
+        }
+    }
+    
+    /**
+     * Register a decider.
+     */
+    public void registerDecider(Class<? extends AllocationDecider> deciderClass, AllocationDecider decider) {
+        availableDeciders.put(deciderClass, decider);
+    }
+}

--- a/src/main/java/io/clustercontroller/allocation/deciders/AllNodesDecider.java
+++ b/src/main/java/io/clustercontroller/allocation/deciders/AllNodesDecider.java
@@ -1,0 +1,28 @@
+package io.clustercontroller.allocation.deciders;
+
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+
+/**
+ * Simple decider that accepts all nodes.
+ * 
+ * Used as fallback when no specific filtering is needed.
+ */
+public class AllNodesDecider implements AllocationDecider {
+    private boolean enabled = true;
+    
+    @Override
+    public Decision canAllocate(String shardId, SearchUnit node, String indexName, NodeRole targetRole) {
+        return Decision.YES;
+    }
+    
+    @Override
+    public String getName() { return "AllNodesDecider"; }
+    
+    @Override
+    public boolean isEnabled() { return enabled; }
+    
+    @Override
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+}

--- a/src/main/java/io/clustercontroller/allocation/deciders/AllocationDecider.java
+++ b/src/main/java/io/clustercontroller/allocation/deciders/AllocationDecider.java
@@ -1,0 +1,42 @@
+package io.clustercontroller.allocation.deciders;
+
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+
+/**
+ * Interface for allocation decision making.
+ * 
+ * Each AllocationDecider implements a specific rule for determining
+ * whether a shard can be allocated to a particular node.
+ * 
+ * Inspired by OpenSearch's AllocationDecider pattern.
+ */
+public interface AllocationDecider {
+    
+    /**
+     * Determine if a shard can be allocated to a node.
+     * 
+     * @param shardId the shard ID to allocate
+     * @param node the target node
+     * @param indexName the index name
+     * @param targetRole the role we're selecting for
+     * @return allocation decision
+     */
+    Decision canAllocate(String shardId, SearchUnit node, String indexName, NodeRole targetRole);
+    
+    /**
+     * Get the name of this decider.
+     */
+    String getName();
+    
+    /**
+     * Check if this decider is enabled.
+     */
+    boolean isEnabled();
+    
+    /**
+     * Enable or disable this decider.
+     */
+    void setEnabled(boolean enabled);
+}

--- a/src/main/java/io/clustercontroller/allocation/deciders/AllocationDecider.java
+++ b/src/main/java/io/clustercontroller/allocation/deciders/AllocationDecider.java
@@ -10,7 +10,7 @@ import io.clustercontroller.models.SearchUnit;
  * Each AllocationDecider implements a specific rule for determining
  * whether a shard can be allocated to a particular node.
  * 
- * Inspired by OpenSearch's AllocationDecider pattern.
+ * Enables modular, configurable allocation policies.
  */
 public interface AllocationDecider {
     

--- a/src/main/java/io/clustercontroller/allocation/deciders/HealthDecider.java
+++ b/src/main/java/io/clustercontroller/allocation/deciders/HealthDecider.java
@@ -1,0 +1,40 @@
+package io.clustercontroller.allocation.deciders;
+
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.HealthState;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+
+/**
+ * Decider that filters nodes based on health status.
+ * 
+ * Rejects nodes with stateAdmin != "NORMAL" or statePulled == RED.
+ */
+public class HealthDecider implements AllocationDecider {
+    private boolean enabled = true;
+    
+    @Override
+    public Decision canAllocate(String shardId, SearchUnit node, String indexName, NodeRole targetRole) {
+        String stateAdmin = node.getStateAdmin();
+        HealthState statePulled = node.getStatePulled();
+        
+        if (stateAdmin == null || !"NORMAL".equalsIgnoreCase(stateAdmin)) {
+            return Decision.NO;
+        }
+        
+        if (statePulled == HealthState.RED) {
+            return Decision.NO;
+        }
+        
+        return Decision.YES;
+    }
+    
+    @Override
+    public String getName() { return "HealthDecider"; }
+    
+    @Override
+    public boolean isEnabled() { return enabled; }
+    
+    @Override
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+}

--- a/src/main/java/io/clustercontroller/allocation/deciders/RoleDecider.java
+++ b/src/main/java/io/clustercontroller/allocation/deciders/RoleDecider.java
@@ -1,0 +1,45 @@
+package io.clustercontroller.allocation.deciders;
+
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+
+/**
+ * Decider that filters nodes based on strict role matching.
+ * 
+ * PRIMARY target: only PRIMARY nodes. REPLICA target: only REPLICA nodes.
+ * Always rejects COORDINATOR nodes.
+ */
+public class RoleDecider implements AllocationDecider {
+    private boolean enabled = true;
+    
+    @Override
+    public Decision canAllocate(String shardId, SearchUnit node, String indexName, NodeRole targetRole) {
+        String nodeRoleString = node.getRole();
+        if (nodeRoleString == null) return Decision.NO;
+        
+        NodeRole nodeRole = NodeRole.fromString(nodeRoleString);
+        if (nodeRole == null) return Decision.NO;
+        
+        if (nodeRole == NodeRole.COORDINATOR) return Decision.NO;
+        
+        if (targetRole == NodeRole.PRIMARY) {
+            return nodeRole == NodeRole.PRIMARY ? Decision.YES : Decision.NO;
+        }
+        
+        if (targetRole == NodeRole.REPLICA) {
+            return nodeRole == NodeRole.REPLICA ? Decision.YES : Decision.NO;
+        }
+        
+        return Decision.NO;
+    }
+    
+    @Override
+    public String getName() { return "RoleDecider"; }
+    
+    @Override
+    public boolean isEnabled() { return enabled; }
+    
+    @Override
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+}

--- a/src/main/java/io/clustercontroller/allocation/deciders/ShardPoolDecider.java
+++ b/src/main/java/io/clustercontroller/allocation/deciders/ShardPoolDecider.java
@@ -1,0 +1,29 @@
+package io.clustercontroller.allocation.deciders;
+
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+
+/**
+ * Decider that filters nodes based on shard pool assignment.
+ * 
+ * Only allows allocation to nodes where node.getShardId() matches the target shardId.
+ */
+public class ShardPoolDecider implements AllocationDecider {
+    private boolean enabled = true;
+    
+    @Override
+    public Decision canAllocate(String shardId, SearchUnit node, String indexName, NodeRole targetRole) {
+        String nodeShardId = node.getShardId();
+        return (nodeShardId != null && nodeShardId.equals(shardId)) ? Decision.YES : Decision.NO;
+    }
+    
+    @Override
+    public String getName() { return "ShardPoolDecider"; }
+    
+    @Override
+    public boolean isEnabled() { return enabled; }
+    
+    @Override
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+}

--- a/src/main/java/io/clustercontroller/enums/Decision.java
+++ b/src/main/java/io/clustercontroller/enums/Decision.java
@@ -1,0 +1,16 @@
+package io.clustercontroller.enums;
+
+/**
+ * Allocation decision result.
+ * 
+ * Merge precedence: NO > THROTTLE > YES
+ */
+public enum Decision {
+    YES, NO, THROTTLE;
+    
+    public Decision merge(Decision other) {
+        if (this == NO || other == NO) return NO;
+        if (this == THROTTLE || other == THROTTLE) return THROTTLE;
+        return YES;
+    }
+}

--- a/src/main/java/io/clustercontroller/enums/NodeRole.java
+++ b/src/main/java/io/clustercontroller/enums/NodeRole.java
@@ -1,0 +1,34 @@
+package io.clustercontroller.enums;
+
+/**
+ * Node roles used by AllocationDeciders.
+ * 
+ * PRIMARY: ingest + search, REPLICA: search only, COORDINATOR: routing only
+ */
+public enum NodeRole {
+    PRIMARY("primary"),
+    REPLICA("replica"), 
+    COORDINATOR("coordinator");
+    
+    private final String value;
+    
+    NodeRole(String value) {
+        this.value = value;
+    }
+    
+    public String getValue() {
+        return value;
+    }
+    
+    public static NodeRole fromString(String value) {
+        if (value == null) return null;
+        
+        String normalized = value.toLowerCase().trim();
+        for (NodeRole role : NodeRole.values()) {
+            if (role.value.equals(normalized)) {
+                return role;
+            }
+        }
+        return null; // Return null for unknown roles instead of throwing exception
+    }
+}

--- a/src/test/java/io/clustercontroller/allocation/AllocationDecisionEngineTest.java
+++ b/src/test/java/io/clustercontroller/allocation/AllocationDecisionEngineTest.java
@@ -1,0 +1,133 @@
+package io.clustercontroller.allocation;
+
+import io.clustercontroller.allocation.deciders.*;
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.HealthState;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AllocationDecisionEngineTest {
+    
+    private AllocationDecisionEngine engine;
+    private SearchUnit healthyPrimary;
+    private SearchUnit unhealthyNode;
+    private SearchUnit coordinatorNode;
+    
+    @BeforeEach
+    void setUp() {
+        engine = new AllocationDecisionEngine();
+        
+        // Register deciders
+        engine.registerDecider(AllNodesDecider.class, new AllNodesDecider());
+        engine.registerDecider(HealthDecider.class, new HealthDecider());
+        engine.registerDecider(RoleDecider.class, new RoleDecider());
+        engine.registerDecider(ShardPoolDecider.class, new ShardPoolDecider());
+        
+        // Create test nodes
+        healthyPrimary = createSearchUnit("node1", "primary", "NORMAL", HealthState.GREEN, "0");
+        unhealthyNode = createSearchUnit("node2", "primary", "NORMAL", HealthState.RED, "0");
+        coordinatorNode = createSearchUnit("coord1", "coordinator", "NORMAL", HealthState.GREEN, "0");
+    }
+    
+    
+    @Test
+    void testDeciderChain() {
+        engine.enableDecider(HealthDecider.class);
+        engine.enableDecider(RoleDecider.class);
+        
+        List<SearchUnit> candidates = Arrays.asList(healthyPrimary, unhealthyNode, coordinatorNode);
+        List<SearchUnit> selected = engine.getAvailableNodesForAllocation("0", "test-index", candidates, NodeRole.PRIMARY);
+        
+        // Only healthy primary should pass
+        assertThat(selected).hasSize(1);
+        assertThat(selected).containsExactly(healthyPrimary);
+    }
+    
+    @Test
+    void testNoDecidersEnabled() {
+        // With no deciders enabled, should return empty list
+        List<SearchUnit> candidates = Arrays.asList(healthyPrimary);
+        List<SearchUnit> selected = engine.getAvailableNodesForAllocation("0", "test-index", candidates, NodeRole.PRIMARY);
+        
+        assertThat(selected).isEmpty();
+    }
+    
+    @Test
+    void testEnableDisableDeciders() {
+        engine.enableDecider(HealthDecider.class);
+        
+        List<SearchUnit> candidates = Arrays.asList(unhealthyNode);
+        
+        // With HealthDecider enabled, unhealthy node rejected
+        List<SearchUnit> selected1 = engine.getAvailableNodesForAllocation("0", "test-index", candidates, NodeRole.PRIMARY);
+        assertThat(selected1).isEmpty();
+        
+        // Disable HealthDecider
+        engine.disableDecider(HealthDecider.class);
+        
+        // Still empty because no deciders enabled
+        List<SearchUnit> selected2 = engine.getAvailableNodesForAllocation("0", "test-index", candidates, NodeRole.PRIMARY);
+        assertThat(selected2).isEmpty();
+        
+        // Enable AllNodesDecider
+        engine.enableDecider(AllNodesDecider.class);
+        List<SearchUnit> selected3 = engine.getAvailableNodesForAllocation("0", "test-index", candidates, NodeRole.PRIMARY);
+        assertThat(selected3).hasSize(1);
+        assertThat(selected3).containsExactly(unhealthyNode);
+    }
+    
+    @Test
+    void testShardPoolFiltering() {
+        SearchUnit wrongShardNode = createSearchUnit("wrong1", "primary", "NORMAL", HealthState.GREEN, "1");
+        
+        engine.enableDecider(ShardPoolDecider.class);
+        
+        List<SearchUnit> candidates = Arrays.asList(healthyPrimary, wrongShardNode);
+        List<SearchUnit> selected = engine.getAvailableNodesForAllocation("0", "test-index", candidates, NodeRole.PRIMARY);
+        
+        // Should only include nodes from shard 0
+        assertThat(selected).hasSize(1);
+        assertThat(selected).containsExactly(healthyPrimary);
+    }
+    
+    @Test
+    void testComplexDeciderChain() {
+        // Enable all deciders
+        engine.enableDecider(HealthDecider.class);
+        engine.enableDecider(RoleDecider.class);
+        engine.enableDecider(ShardPoolDecider.class);
+        
+        SearchUnit perfectNode = createSearchUnit("perfect", "primary", "NORMAL", HealthState.GREEN, "0");
+        SearchUnit wrongShardNode = createSearchUnit("wrong-shard", "primary", "NORMAL", HealthState.GREEN, "1");
+        SearchUnit wrongRoleNode = createSearchUnit("wrong-role", "replica", "NORMAL", HealthState.GREEN, "0");
+        SearchUnit unhealthyNode = createSearchUnit("unhealthy", "primary", "NORMAL", HealthState.RED, "0");
+        SearchUnit drainedNode = createSearchUnit("drained", "primary", "DRAIN", HealthState.GREEN, "0");
+        
+        List<SearchUnit> candidates = Arrays.asList(
+            perfectNode, wrongShardNode, wrongRoleNode, unhealthyNode, drainedNode
+        );
+        
+        List<SearchUnit> selected = engine.getAvailableNodesForAllocation("0", "test-index", candidates, NodeRole.PRIMARY);
+        
+        // Only perfect node should pass all deciders
+        assertThat(selected).hasSize(1);
+        assertThat(selected).containsExactly(perfectNode);
+    }
+    
+    private SearchUnit createSearchUnit(String name, String role, String stateAdmin, HealthState statePulled, String shardId) {
+        SearchUnit unit = new SearchUnit();
+        unit.setName(name);
+        unit.setRole(role);
+        unit.setStateAdmin(stateAdmin);
+        unit.setStatePulled(statePulled);
+        unit.setShardId(shardId);
+        return unit;
+    }
+}

--- a/src/test/java/io/clustercontroller/allocation/deciders/AllNodesDeciderTest.java
+++ b/src/test/java/io/clustercontroller/allocation/deciders/AllNodesDeciderTest.java
@@ -1,0 +1,59 @@
+package io.clustercontroller.allocation.deciders;
+
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.HealthState;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AllNodesDeciderTest {
+    
+    private AllNodesDecider decider;
+    
+    @BeforeEach
+    void setUp() {
+        decider = new AllNodesDecider();
+    }
+    
+    @Test
+    void testAcceptsAllNodes() {
+        SearchUnit primaryNode = createSearchUnit("node1", "primary", HealthState.GREEN);
+        SearchUnit replicaNode = createSearchUnit("node2", "replica", HealthState.YELLOW);
+        SearchUnit coordinatorNode = createSearchUnit("coord1", "coordinator", HealthState.GREEN);
+        SearchUnit unhealthyNode = createSearchUnit("node3", "primary", HealthState.RED);
+        
+        assertThat(decider.canAllocate("0", primaryNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.YES);
+        assertThat(decider.canAllocate("0", replicaNode, "test-index", NodeRole.REPLICA))
+            .isEqualTo(Decision.YES);
+        assertThat(decider.canAllocate("0", coordinatorNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.YES);
+        assertThat(decider.canAllocate("0", unhealthyNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.YES);
+    }
+    
+    @Test
+    void testDeciderProperties() {
+        assertThat(decider.getName()).isEqualTo("AllNodesDecider");
+        assertThat(decider.isEnabled()).isTrue();
+        
+        decider.setEnabled(false);
+        assertThat(decider.isEnabled()).isFalse();
+        
+        decider.setEnabled(true);
+        assertThat(decider.isEnabled()).isTrue();
+    }
+    
+    private SearchUnit createSearchUnit(String name, String role, HealthState healthState) {
+        SearchUnit unit = new SearchUnit();
+        unit.setName(name);
+        unit.setRole(role);
+        unit.setStateAdmin("NORMAL");
+        unit.setStatePulled(healthState);
+        unit.setShardId("0");
+        return unit;
+    }
+}

--- a/src/test/java/io/clustercontroller/allocation/deciders/HealthDeciderTest.java
+++ b/src/test/java/io/clustercontroller/allocation/deciders/HealthDeciderTest.java
@@ -1,0 +1,61 @@
+package io.clustercontroller.allocation.deciders;
+
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.HealthState;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HealthDeciderTest {
+    
+    private HealthDecider decider;
+    
+    @BeforeEach
+    void setUp() {
+        decider = new HealthDecider();
+    }
+    
+    @Test
+    void testHealthyNodesAccepted() {
+        SearchUnit greenNode = createSearchUnit("node1", "primary", "NORMAL", HealthState.GREEN);
+        SearchUnit yellowNode = createSearchUnit("node2", "replica", "NORMAL", HealthState.YELLOW);
+        
+        assertThat(decider.canAllocate("0", greenNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.YES);
+        assertThat(decider.canAllocate("0", yellowNode, "test-index", NodeRole.REPLICA))
+            .isEqualTo(Decision.YES);
+    }
+    
+    @Test
+    void testUnhealthyNodesRejected() {
+        SearchUnit redNode = createSearchUnit("node1", "primary", "NORMAL", HealthState.RED);
+        SearchUnit drainedNode = createSearchUnit("node2", "primary", "DRAIN", HealthState.GREEN);
+        SearchUnit nullAdminNode = createSearchUnit("node3", "primary", null, HealthState.GREEN);
+        
+        assertThat(decider.canAllocate("0", redNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.NO);
+        assertThat(decider.canAllocate("0", drainedNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.NO);
+        assertThat(decider.canAllocate("0", nullAdminNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.NO);
+    }
+    
+    @Test
+    void testDeciderProperties() {
+        assertThat(decider.getName()).isEqualTo("HealthDecider");
+        assertThat(decider.isEnabled()).isTrue();
+    }
+    
+    private SearchUnit createSearchUnit(String name, String role, String stateAdmin, HealthState statePulled) {
+        SearchUnit unit = new SearchUnit();
+        unit.setName(name);
+        unit.setRole(role);
+        unit.setStateAdmin(stateAdmin);
+        unit.setStatePulled(statePulled);
+        unit.setShardId("0");
+        return unit;
+    }
+}

--- a/src/test/java/io/clustercontroller/allocation/deciders/RoleDeciderTest.java
+++ b/src/test/java/io/clustercontroller/allocation/deciders/RoleDeciderTest.java
@@ -1,0 +1,81 @@
+package io.clustercontroller.allocation.deciders;
+
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.HealthState;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RoleDeciderTest {
+    
+    private RoleDecider decider;
+    
+    @BeforeEach
+    void setUp() {
+        decider = new RoleDecider();
+    }
+    
+    @Test
+    void testPrimaryTargetRole() {
+        SearchUnit primaryNode = createSearchUnit("node1", "primary");
+        SearchUnit replicaNode = createSearchUnit("node2", "replica");
+        SearchUnit coordinatorNode = createSearchUnit("coord1", "coordinator");
+        
+        // For PRIMARY target, only PRIMARY nodes allowed
+        assertThat(decider.canAllocate("0", primaryNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.YES);
+        assertThat(decider.canAllocate("0", replicaNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.NO);
+        assertThat(decider.canAllocate("0", coordinatorNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.NO);
+    }
+    
+    @Test
+    void testReplicaTargetRole() {
+        SearchUnit primaryNode = createSearchUnit("node1", "primary");
+        SearchUnit replicaNode = createSearchUnit("node2", "replica");
+        SearchUnit coordinatorNode = createSearchUnit("coord1", "coordinator");
+        
+        // For REPLICA target, only REPLICA nodes allowed
+        assertThat(decider.canAllocate("0", primaryNode, "test-index", NodeRole.REPLICA))
+            .isEqualTo(Decision.NO);
+        assertThat(decider.canAllocate("0", replicaNode, "test-index", NodeRole.REPLICA))
+            .isEqualTo(Decision.YES);
+        assertThat(decider.canAllocate("0", coordinatorNode, "test-index", NodeRole.REPLICA))
+            .isEqualTo(Decision.NO);
+    }
+    
+    @Test
+    void testCoordinatorAlwaysRejected() {
+        SearchUnit coordinatorNode = createSearchUnit("coord1", "coordinator");
+        
+        assertThat(decider.canAllocate("0", coordinatorNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.NO);
+        assertThat(decider.canAllocate("0", coordinatorNode, "test-index", NodeRole.REPLICA))
+            .isEqualTo(Decision.NO);
+    }
+    
+    @Test
+    void testNullRoleHandling() {
+        SearchUnit nullRoleNode = createSearchUnit("node1", null);
+        SearchUnit unknownRoleNode = createSearchUnit("node2", "unknown");
+        
+        assertThat(decider.canAllocate("0", nullRoleNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.NO);
+        assertThat(decider.canAllocate("0", unknownRoleNode, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.NO);
+    }
+    
+    private SearchUnit createSearchUnit(String name, String role) {
+        SearchUnit unit = new SearchUnit();
+        unit.setName(name);
+        unit.setRole(role);
+        unit.setStateAdmin("NORMAL");
+        unit.setStatePulled(HealthState.GREEN);
+        unit.setShardId("0");
+        return unit;
+    }
+}

--- a/src/test/java/io/clustercontroller/allocation/deciders/ShardPoolDeciderTest.java
+++ b/src/test/java/io/clustercontroller/allocation/deciders/ShardPoolDeciderTest.java
@@ -1,0 +1,60 @@
+package io.clustercontroller.allocation.deciders;
+
+import io.clustercontroller.enums.Decision;
+import io.clustercontroller.enums.HealthState;
+import io.clustercontroller.enums.NodeRole;
+import io.clustercontroller.models.SearchUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShardPoolDeciderTest {
+    
+    private ShardPoolDecider decider;
+    
+    @BeforeEach
+    void setUp() {
+        decider = new ShardPoolDecider();
+    }
+    
+    @Test
+    void testMatchingShardPool() {
+        SearchUnit nodeInShard0 = createSearchUnit("node1", "0");
+        SearchUnit nodeInShard1 = createSearchUnit("node2", "1");
+        
+        assertThat(decider.canAllocate("0", nodeInShard0, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.YES);
+        assertThat(decider.canAllocate("1", nodeInShard1, "test-index", NodeRole.REPLICA))
+            .isEqualTo(Decision.YES);
+    }
+    
+    @Test
+    void testMismatchedShardPool() {
+        SearchUnit nodeInShard0 = createSearchUnit("node1", "0");
+        SearchUnit nodeInShard1 = createSearchUnit("node2", "1");
+        
+        assertThat(decider.canAllocate("1", nodeInShard0, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.NO);
+        assertThat(decider.canAllocate("0", nodeInShard1, "test-index", NodeRole.REPLICA))
+            .isEqualTo(Decision.NO);
+    }
+    
+    @Test
+    void testNullShardId() {
+        SearchUnit nodeWithNullShard = createSearchUnit("node1", null);
+        
+        assertThat(decider.canAllocate("0", nodeWithNullShard, "test-index", NodeRole.PRIMARY))
+            .isEqualTo(Decision.NO);
+    }
+    
+    private SearchUnit createSearchUnit(String name, String shardId) {
+        SearchUnit unit = new SearchUnit();
+        unit.setName(name);
+        unit.setRole("primary");
+        unit.setStateAdmin("NORMAL");
+        unit.setStatePulled(HealthState.GREEN);
+        unit.setShardId(shardId);
+        return unit;
+    }
+}

--- a/src/test/java/io/clustercontroller/enums/DecisionTest.java
+++ b/src/test/java/io/clustercontroller/enums/DecisionTest.java
@@ -1,0 +1,22 @@
+package io.clustercontroller.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DecisionTest {
+    
+    @Test
+    void testMergeLogic() {
+        // NO overrides everything
+        assertThat(Decision.YES.merge(Decision.NO)).isEqualTo(Decision.NO);
+        assertThat(Decision.NO.merge(Decision.YES)).isEqualTo(Decision.NO);
+        assertThat(Decision.THROTTLE.merge(Decision.NO)).isEqualTo(Decision.NO);
+        
+        // THROTTLE overrides YES
+        assertThat(Decision.YES.merge(Decision.THROTTLE)).isEqualTo(Decision.THROTTLE);
+        assertThat(Decision.THROTTLE.merge(Decision.YES)).isEqualTo(Decision.THROTTLE);
+        
+        // YES with YES stays YES
+        assertThat(Decision.YES.merge(Decision.YES)).isEqualTo(Decision.YES);
+    }
+}

--- a/src/test/java/io/clustercontroller/enums/NodeRoleTest.java
+++ b/src/test/java/io/clustercontroller/enums/NodeRoleTest.java
@@ -1,0 +1,40 @@
+package io.clustercontroller.enums;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for NodeRole enum.
+ */
+class NodeRoleTest {
+    
+    @Test
+    void testFromStringValidValues() {
+        assertThat(NodeRole.fromString("primary")).isEqualTo(NodeRole.PRIMARY);
+        assertThat(NodeRole.fromString("replica")).isEqualTo(NodeRole.REPLICA);
+        assertThat(NodeRole.fromString("coordinator")).isEqualTo(NodeRole.COORDINATOR);
+        
+        // Test case insensitive
+        assertThat(NodeRole.fromString("PRIMARY")).isEqualTo(NodeRole.PRIMARY);
+        assertThat(NodeRole.fromString("REPLICA")).isEqualTo(NodeRole.REPLICA);
+        
+        // Test with whitespace
+        assertThat(NodeRole.fromString(" primary ")).isEqualTo(NodeRole.PRIMARY);
+        assertThat(NodeRole.fromString("\treplica\n")).isEqualTo(NodeRole.REPLICA);
+    }
+    
+    @Test
+    void testFromStringInvalidValues() {
+        assertThat(NodeRole.fromString("invalid")).isNull();
+        assertThat(NodeRole.fromString("")).isNull();
+        assertThat(NodeRole.fromString("   ")).isNull();
+        assertThat(NodeRole.fromString(null)).isNull();
+    }
+    
+    @Test
+    void testGetValue() {
+        assertThat(NodeRole.PRIMARY.getValue()).isEqualTo("primary");
+        assertThat(NodeRole.REPLICA.getValue()).isEqualTo("replica");
+        assertThat(NodeRole.COORDINATOR.getValue()).isEqualTo("coordinator");
+    }
+}


### PR DESCRIPTION
This PR implements a flexible AllocationDecider framework that enables modular, configurable node selection for shard allocation.

## Key Features
- **Decision-based chain pattern** for composable allocation policies
- **4 configurable deciders**: Health, Role, ShardPool, AllNodes
- **Runtime configuration** - Enable/disable deciders dynamically

## Architecture
- `AllocationDecisionEngine` orchestrates the decider chain
- Individual deciders implement specific filtering rules
- Decision merge logic: NO > THROTTLE > YES

Other Deciders can be added as required. For the first version we will just require the 4 deciders for shard allocation planning