### PR TITLE
Index - basic deleteIndex flow 

### DIFF
--- a/src/main/java/io/clustercontroller/indices/IndexManager.java
+++ b/src/main/java/io/clustercontroller/indices/IndexManager.java
@@ -72,12 +72,11 @@ public class IndexManager {
         newIndex.setIndexName(request.getIndexName());
         newIndex.setShardReplicaCount(shardReplicaCount);
         newIndex.setAllocationPlan(allocationPlan);
-        newIndex.setActive(request.isActive());
         
         // Store the index configuration
         String documentId = metadataStore.createIndexConfig(newIndex);
-        log.info("CreateIndex - Successfully created index configuration for '{}' with document ID: {}, active: {}", 
-            newIndex.getIndexName(), documentId, newIndex.isActive());
+        log.info("CreateIndex - Successfully created index configuration for '{}' with document ID: {}", 
+            newIndex.getIndexName(), documentId);
         
         // Store mappings if provided
         if (request.getMappings() != null && !request.getMappings().trim().isEmpty()) {
@@ -115,10 +114,7 @@ public class IndexManager {
     private static class CreateIndexRequest {
         @JsonProperty("index_name")
         private String indexName;
-        
-        @JsonProperty("active")
-        private boolean active = false; // Default to false
-        
+
         @JsonProperty("mappings")
         private String mappings; // Optional mappings JSON
         

--- a/src/main/java/io/clustercontroller/indices/IndexManager.java
+++ b/src/main/java/io/clustercontroller/indices/IndexManager.java
@@ -3,8 +3,10 @@ package io.clustercontroller.indices;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.clustercontroller.models.Index;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.clustercontroller.models.ShardAllocation;
 import io.clustercontroller.models.ShardData;
 import io.clustercontroller.models.SearchUnit;
+import io.clustercontroller.models.SearchUnitGoalState;
 import io.clustercontroller.store.MetadataStore;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * Manages index lifecycle operations.
@@ -92,9 +96,44 @@ public class IndexManager {
         
     }
     
-    public void deleteIndex(String indexConfig) throws Exception {
-        log.info("Deleting index with config: {}", indexConfig);
-        // TODO: Implement index deletion logic
+    public void deleteIndex(String input) throws Exception {
+        log.info("IndexShard - Deleting index from input: {}", input);
+        
+        // Parse the JSON input to extract delete index configuration
+        DeleteIndexRequest request = parseDeleteIndexRequest(input);
+        
+        log.info("DeleteIndex - Parsed index name: {}", request.getIndexName());
+        
+        // Validate the parsed input
+        if (request.getIndexName() == null || request.getIndexName().isEmpty()) {
+            throw new Exception("Index name cannot be null or empty");
+        }
+        
+        String indexName = request.getIndexName();
+        
+        // Check if index exists
+        List<Index> allIndices = metadataStore.getAllIndexConfigs();
+        Index targetIndex = allIndices.stream()
+            .filter(index -> indexName.equals(index.getIndexName()))
+            .findFirst()
+            .orElse(null);
+            
+        if (targetIndex == null) {
+            log.warn("DeleteIndex - Index '{}' not found, nothing to delete", indexName);
+            return;
+        }
+        
+        // Step 1: Remove all planned allocations for this index
+        deleteAllPlannedAllocationsFromIndex(indexName);
+        
+        // Step 2: Delete the index configuration from etcd
+        metadataStore.deleteIndexConfig(indexName);
+        log.info("DeleteIndex - Successfully deleted index configuration for '{}'", indexName);
+        
+        // Step 3: Clean up goal states for this deleted index
+        cleanupGoalStatesForDeletedIndex(indexName);
+        
+        log.info("DeleteIndex - Index '{}' deletion completed.", indexName);
     }
     
     public void planShardAllocation() throws Exception {
@@ -104,6 +143,95 @@ public class IndexManager {
 
     private CreateIndexRequest parseCreateIndexRequest(String input) throws Exception {
         return objectMapper.readValue(input, CreateIndexRequest.class);
+    }
+    
+    private DeleteIndexRequest parseDeleteIndexRequest(String input) throws Exception {
+        return objectMapper.readValue(input, DeleteIndexRequest.class);
+    }
+    
+    /**
+     * Delete all planned allocations from an index
+     */
+    private void deleteAllPlannedAllocationsFromIndex(String indexName) throws Exception {
+        log.info("DeleteIndex - Cleaning up ALL planned allocations from index '{}'", indexName);
+        
+        try {
+            List<ShardAllocation> plannedAllocations = metadataStore.getAllPlannedAllocations(indexName);
+            
+            for (ShardAllocation allocation : plannedAllocations) {
+                try {
+                    metadataStore.deletePlannedAllocation(indexName, allocation.getShardId());
+                } catch (Exception e) {
+                    log.error("DeleteIndex - Failed to delete planned allocation {}/{}: {}", 
+                        indexName, allocation.getShardId(), e.getMessage());
+                }
+            }
+            
+            log.info("DeleteIndex - Cleaned up {} planned allocations from index '{}'", 
+                plannedAllocations.size(), indexName);
+                
+        } catch (Exception e) {
+            log.error("DeleteIndex - Failed to cleanup planned allocations from index '{}': {}", 
+                indexName, e.getMessage());
+            throw e;
+        }
+    }
+    
+    /**
+     * Cleans up goal states (local shards) for an index from all search units
+     */
+    private void cleanupGoalStatesForDeletedIndex(String deletedIndexName) throws Exception {
+        log.info("DeleteIndex - Starting immediate goal state cleanup for deleted index '{}'", deletedIndexName);
+        
+        try {
+            // Get all search units to check their goal states
+            List<SearchUnit> allSearchUnits = metadataStore.getAllSearchUnits();
+            
+            for (SearchUnit searchUnit : allSearchUnits) {
+                String unitName = searchUnit.getName();
+                
+                try {
+                    // Get current goal state for this unit
+                    Optional<SearchUnitGoalState> goalStateOpt = metadataStore.getSearchUnitGoalState(unitName);
+                    
+                    if (!goalStateOpt.isPresent()) {
+                        log.debug("DeleteIndex - No goal state found for unit '{}'", unitName);
+                        continue;
+                    }
+                    
+                    SearchUnitGoalState goalState = goalStateOpt.get();
+                    
+                    // Check if this unit has the deleted index in its goal state
+                    if (!goalState.getLocalShards().containsKey(deletedIndexName)) {
+                        log.debug("DeleteIndex - Unit '{}' does not have deleted index '{}' in goal state", 
+                            unitName, deletedIndexName);
+                        continue;
+                    }
+                    
+                    // Remove the deleted index from goal state
+                    Map<String, Map<String, String>> localShards = goalState.getLocalShards();
+                    localShards.remove(deletedIndexName);
+                    
+                    // Save updated goal state
+                    metadataStore.updateSearchUnitGoalState(unitName, goalState);
+                    
+                    log.info("DeleteIndex - Removed deleted index '{}' from goal state of unit '{}'", 
+                        deletedIndexName, unitName);
+                        
+                } catch (Exception e) {
+                    log.error("DeleteIndex - Failed to cleanup goal state for unit '{}': {}", 
+                        unitName, e.getMessage(), e);
+                }
+            }
+            
+        } catch (Exception e) {
+            log.error("DeleteIndex - Failed to get search units for goal state cleanup: {}", 
+                e.getMessage(), e);
+            throw e;
+        }
+        
+        log.info("DeleteIndex - Completed immediate goal state cleanup for deleted index '{}'", 
+            deletedIndexName);
     }
 
     /**
@@ -120,5 +248,15 @@ public class IndexManager {
         
         @JsonProperty("settings")
         private String settings; // Optional settings JSON
+    }
+    
+    /**
+     * Data class to hold parsed delete index request
+     */
+    @Data
+    @NoArgsConstructor
+    private static class DeleteIndexRequest {
+        @JsonProperty("index_name")
+        private String indexName;
     }
 }

--- a/src/main/java/io/clustercontroller/indices/IndexManager.java
+++ b/src/main/java/io/clustercontroller/indices/IndexManager.java
@@ -1,7 +1,18 @@
 package io.clustercontroller.indices;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.clustercontroller.models.Index;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.clustercontroller.models.ShardData;
+import io.clustercontroller.models.SearchUnit;
 import io.clustercontroller.store.MetadataStore;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Manages index lifecycle operations.
@@ -11,23 +22,107 @@ import lombok.extern.slf4j.Slf4j;
 public class IndexManager {
     
     private final MetadataStore metadataStore;
+    private final ObjectMapper objectMapper;
     
     public IndexManager(MetadataStore metadataStore) {
         this.metadataStore = metadataStore;
+        this.objectMapper = new ObjectMapper();
     }
     
-    public void createIndex(String indexConfig) {
+    public void createIndex(String indexConfig) throws Exception {
         log.info("Creating index with config: {}", indexConfig);
-        // TODO: Implement index creation logic
+        
+        // Parse the JSON input to extract index configuration
+        CreateIndexRequest request = parseCreateIndexRequest(indexConfig);
+        
+        log.info("CreateIndex - Parsed index name: {}", request.getIndexName());
+        
+        // Validate the parsed input
+        if (request.getIndexName() == null || request.getIndexName().isEmpty()) {
+            throw new Exception("Index name cannot be null or empty");
+        }
+        
+        // Check if index already exists
+        if (metadataStore.getIndexConfig(request.getIndexName()).isPresent()) {
+            log.info("CreateIndex - Index '{}' already exists, skipping creation", request.getIndexName());
+            return;
+        }
+        
+        // Get all available search units for allocation planning
+        List<SearchUnit> availableUnits = metadataStore.getAllSearchUnits();
+        
+        if (availableUnits.isEmpty()) {
+            throw new Exception("No search units available for index allocation");
+        }
+        
+        // TODO: Determine number of shards from settings, adding default 1 shard for now
+        int numberOfShards = 1;
+        
+        // TODO: Calculate maximum replicas per shard based on available search units
+        List<Integer> shardReplicaCount = new ArrayList<>();
+        shardReplicaCount.add(1);
+        
+        log.info("CreateIndex - Using {} shards with replica count: {}", numberOfShards, shardReplicaCount);
+        
+        // TODO: Create allocation plan
+        List<ShardData> allocationPlan = new ArrayList<>();
+        
+        // Create the new Index configuration
+        Index newIndex = new Index();
+        newIndex.setIndexName(request.getIndexName());
+        newIndex.setShardReplicaCount(shardReplicaCount);
+        newIndex.setAllocationPlan(allocationPlan);
+        newIndex.setActive(request.isActive());
+        
+        // Store the index configuration
+        String documentId = metadataStore.createIndexConfig(newIndex);
+        log.info("CreateIndex - Successfully created index configuration for '{}' with document ID: {}, active: {}", 
+            newIndex.getIndexName(), documentId, newIndex.isActive());
+        
+        // Store mappings if provided
+        if (request.getMappings() != null && !request.getMappings().trim().isEmpty()) {
+            metadataStore.setIndexMappings(request.getIndexName(), request.getMappings());
+            log.info("CreateIndex - Set mappings for index '{}'", request.getIndexName());
+        }
+        
+        // Store settings if provided
+        if (request.getSettings() != null && !request.getSettings().trim().isEmpty()) {
+            metadataStore.setIndexSettings(request.getIndexName(), request.getSettings());
+            log.info("CreateIndex - Set settings for index '{}'", request.getIndexName());
+        }
+        
     }
     
-    public void deleteIndex(String indexConfig) {
+    public void deleteIndex(String indexConfig) throws Exception {
         log.info("Deleting index with config: {}", indexConfig);
         // TODO: Implement index deletion logic
     }
     
-    public void planShardAllocation() {
+    public void planShardAllocation() throws Exception {
         log.info("Planning shard allocation");
         // TODO: Implement shard allocation planning logic
+    }
+
+    private CreateIndexRequest parseCreateIndexRequest(String input) throws Exception {
+        return objectMapper.readValue(input, CreateIndexRequest.class);
+    }
+
+    /**
+     * Data class to hold parsed create index request
+     */
+    @Data
+    @NoArgsConstructor
+    private static class CreateIndexRequest {
+        @JsonProperty("index_name")
+        private String indexName;
+        
+        @JsonProperty("active")
+        private boolean active = false; // Default to false
+        
+        @JsonProperty("mappings")
+        private String mappings; // Optional mappings JSON
+        
+        @JsonProperty("settings")
+        private String settings; // Optional settings JSON
     }
 }

--- a/src/main/java/io/clustercontroller/models/Index.java
+++ b/src/main/java/io/clustercontroller/models/Index.java
@@ -33,9 +33,6 @@ public class Index {
     @JsonProperty("allocation_plan")
     private List<ShardData> allocationPlan = new ArrayList<>();
     
-    @JsonProperty("active")
-    private boolean active = false; // Default to false for rolling deployment support
-    
     @JsonProperty("created_at")
     private String createdAt = java.time.OffsetDateTime.now().toString(); // ISO timestamp for proper ordering
     

--- a/src/main/java/io/clustercontroller/models/Index.java
+++ b/src/main/java/io/clustercontroller/models/Index.java
@@ -1,0 +1,56 @@
+package io.clustercontroller.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.clustercontroller.models.ShardData;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Index represents index configuration stored in etcd at:
+ * <cluster-name>/indices/<index-name>/conf
+ */
+@Data
+@NoArgsConstructor
+public class Index {
+    @JsonProperty("id")
+    private String id;
+    
+    @JsonProperty("index_name")
+    private String indexName;
+    
+    @JsonProperty("shard_replica_count")
+    private List<Integer> shardReplicaCount = new ArrayList<>();
+    
+    @JsonProperty("settings")
+    private Map<String, Object> settings;
+    
+    @JsonProperty("mappings")
+    private Map<String, Object> mappings;
+    
+    @JsonProperty("allocation_plan")
+    private List<ShardData> allocationPlan = new ArrayList<>();
+    
+    @JsonProperty("active")
+    private boolean active = false; // Default to false for rolling deployment support
+    
+    @JsonProperty("created_at")
+    private String createdAt = java.time.OffsetDateTime.now().toString(); // ISO timestamp for proper ordering
+    
+    public Index(String indexName, List<Integer> shardReplicaCount) {
+        this.indexName = indexName;
+        this.shardReplicaCount = shardReplicaCount != null ? shardReplicaCount : new ArrayList<>();
+        this.allocationPlan = new ArrayList<>();
+    }
+    
+    // Custom setters to maintain null safety
+    public void setShardReplicaCount(List<Integer> shardReplicaCount) { 
+        this.shardReplicaCount = shardReplicaCount != null ? shardReplicaCount : new ArrayList<>(); 
+    }
+    
+    public void setAllocationPlan(List<ShardData> allocationPlan) { 
+        this.allocationPlan = allocationPlan != null ? allocationPlan : new ArrayList<>(); 
+    }
+} 

--- a/src/main/java/io/clustercontroller/models/Index.java
+++ b/src/main/java/io/clustercontroller/models/Index.java
@@ -36,6 +36,9 @@ public class Index {
     @JsonProperty("created_at")
     private String createdAt = java.time.OffsetDateTime.now().toString(); // ISO timestamp for proper ordering
     
+    @JsonProperty("active")
+    private boolean active = true;
+    
     public Index(String indexName, List<Integer> shardReplicaCount) {
         this.indexName = indexName;
         this.shardReplicaCount = shardReplicaCount != null ? shardReplicaCount : new ArrayList<>();

--- a/src/main/java/io/clustercontroller/models/ShardAllocation.java
+++ b/src/main/java/io/clustercontroller/models/ShardAllocation.java
@@ -1,0 +1,47 @@
+package io.clustercontroller.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a planned shard allocation for a specific shard
+ */
+@Data
+@NoArgsConstructor
+public class ShardAllocation {
+    
+    @JsonProperty("index_name")
+    private String indexName;
+    
+    @JsonProperty("shard_id")
+    private String shardId;
+    
+    @JsonProperty("target_nodes")
+    private List<String> targetNodes = new ArrayList<>();
+    
+    @JsonProperty("allocation_type")
+    private String allocationType; // e.g., "PRIMARY", "REPLICA"
+    
+    @JsonProperty("status")
+    private String status; // e.g., "PLANNED", "IN_PROGRESS", "COMPLETED"
+    
+    @JsonProperty("created_at")
+    private String createdAt = java.time.OffsetDateTime.now().toString();
+    
+    @JsonProperty("updated_at")
+    private String updatedAt = java.time.OffsetDateTime.now().toString();
+    
+    public ShardAllocation(String indexName, String shardId) {
+        this.indexName = indexName;
+        this.shardId = shardId;
+    }
+    
+    // Custom setter to maintain null safety
+    public void setTargetNodes(List<String> targetNodes) {
+        this.targetNodes = targetNodes != null ? targetNodes : new ArrayList<>();
+    }
+}

--- a/src/main/java/io/clustercontroller/models/ShardData.java
+++ b/src/main/java/io/clustercontroller/models/ShardData.java
@@ -1,0 +1,43 @@
+package io.clustercontroller.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * ShardData represents shard allocation data
+ */
+@Data
+@NoArgsConstructor
+public class ShardData {
+    @JsonProperty("shard_index_name")
+    private String shardIndexName;
+    
+    @JsonProperty("shard_id")
+    private String shardId;
+    
+    @JsonProperty("ingest_units")
+    private List<String> ingestUnits = new ArrayList<>();
+    
+    @JsonProperty("search_units")
+    private List<String> searchUnits = new ArrayList<>();
+    
+    @JsonProperty("status")
+    private String status;
+    
+    public ShardData(String shardIndexName, String shardId) {
+        this.shardIndexName = shardIndexName;
+        this.shardId = shardId;
+    }
+    
+    // Custom setters to maintain null safety
+    public void setIngestUnits(List<String> ingestUnits) { 
+        this.ingestUnits = ingestUnits != null ? ingestUnits : new ArrayList<>(); 
+    }
+    
+    public void setSearchUnits(List<String> searchUnits) { 
+        this.searchUnits = searchUnits != null ? searchUnits : new ArrayList<>(); 
+    }
+}

--- a/src/main/java/io/clustercontroller/store/MetadataStore.java
+++ b/src/main/java/io/clustercontroller/store/MetadataStore.java
@@ -1,7 +1,7 @@
 package io.clustercontroller.store;
 
 import io.clustercontroller.models.Index;
-
+import io.clustercontroller.models.ShardAllocation;
 import io.clustercontroller.models.TaskMetadata;
 import io.clustercontroller.models.SearchUnit;
 import io.clustercontroller.models.SearchUnitActualState;
@@ -97,6 +97,11 @@ public interface MetadataStore {
      * Get search unit actual state
      */
     Optional<SearchUnitActualState> getSearchUnitActualState(String unitName) throws Exception;
+    
+    /**
+     * Update search unit goal state
+     */
+    void updateSearchUnitGoalState(String unitName, SearchUnitGoalState goalState) throws Exception;
     // =================================================================
     // INDEX CONFIGURATIONS OPERATIONS
     // =================================================================
@@ -104,7 +109,7 @@ public interface MetadataStore {
     /**
      * Get all index configurations
      */
-    List<String> getAllIndexConfigs() throws Exception;
+    List<Index> getAllIndexConfigs() throws Exception;
     
     /**
      * Get index configuration by name
@@ -135,6 +140,20 @@ public interface MetadataStore {
      * Set index settings
      */
     void setIndexSettings(String indexName, String settings) throws Exception;
+    
+    // =================================================================
+    // SHARD ALLOCATION OPERATIONS
+    // =================================================================
+    
+    /**
+     * Get all planned allocations for an index
+     */
+    List<ShardAllocation> getAllPlannedAllocations(String indexName) throws Exception;
+    
+    /**
+     * Delete a planned allocation for a specific shard
+     */
+    void deletePlannedAllocation(String indexName, String shardId) throws Exception;
     
     // =================================================================
     // CLUSTER OPERATIONS

--- a/src/main/java/io/clustercontroller/store/MetadataStore.java
+++ b/src/main/java/io/clustercontroller/store/MetadataStore.java
@@ -1,5 +1,7 @@
 package io.clustercontroller.store;
 
+import io.clustercontroller.models.Index;
+
 import io.clustercontroller.models.TaskMetadata;
 import io.clustercontroller.models.SearchUnit;
 import io.clustercontroller.models.SearchUnitActualState;
@@ -112,17 +114,27 @@ public interface MetadataStore {
     /**
      * Create new index configuration
      */
-    String createIndexConfig(String indexName, String indexConfig) throws Exception;
+    String createIndexConfig(Index index) throws Exception;
     
     /**
      * Update index configuration
      */
-    void updateIndexConfig(String indexName, String indexConfig) throws Exception;
+    void updateIndexConfig(Index index) throws Exception;
     
     /**
      * Delete index configuration
      */
     void deleteIndexConfig(String indexName) throws Exception;
+    
+    /**
+     * Set index mappings
+     */
+    void setIndexMappings(String indexName, String mappings) throws Exception;
+    
+    /**
+     * Set index settings
+     */
+    void setIndexSettings(String indexName, String settings) throws Exception;
     
     // =================================================================
     // CLUSTER OPERATIONS

--- a/src/test/java/io/clustercontroller/indices/IndexManagerTest.java
+++ b/src/test/java/io/clustercontroller/indices/IndexManagerTest.java
@@ -1,0 +1,309 @@
+package io.clustercontroller.indices;
+
+import io.clustercontroller.models.Index;
+import io.clustercontroller.models.SearchUnit;
+import io.clustercontroller.store.MetadataStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class IndexManagerTest {
+
+    @Mock
+    private MetadataStore metadataStore;
+
+    private IndexManager indexManager;
+
+    @BeforeEach
+    void setUp() {
+        indexManager = new IndexManager(metadataStore);
+    }
+
+    @Test
+    void testCreateIndex_Success() throws Exception {
+        // Given
+        String indexName = "test-index";
+        List<SearchUnit> availableSearchUnits = createMockSearchUnits();
+        String createIndexRequestJson = """
+            {
+                "index_name": "test-index",
+                "active": false,
+                "mappings": "{\\"properties\\": {\\"field1\\": {\\"type\\": \\"text\\"}}}",
+                "settings": "{\\"number_of_shards\\": 1}"
+            }
+            """;
+
+        // Mock dependencies
+        when(metadataStore.getIndexConfig(indexName)).thenReturn(Optional.empty());
+        when(metadataStore.getAllSearchUnits()).thenReturn(availableSearchUnits);
+        when(metadataStore.createIndexConfig(any(Index.class))).thenReturn("doc-id-123");
+
+        // When
+        indexManager.createIndex(createIndexRequestJson);
+
+        // Then
+        ArgumentCaptor<Index> indexCaptor = ArgumentCaptor.forClass(Index.class);
+        verify(metadataStore).createIndexConfig(indexCaptor.capture());
+
+        Index capturedIndex = indexCaptor.getValue();
+        assertThat(capturedIndex.getIndexName()).isEqualTo(indexName);
+        assertThat(capturedIndex.isActive()).isFalse();
+        assertThat(capturedIndex.getShardReplicaCount()).isNotNull();
+        assertThat(capturedIndex.getAllocationPlan()).isNotNull();
+        assertThat(capturedIndex.getCreatedAt()).isNotNull();
+
+        verify(metadataStore).getAllSearchUnits();
+        
+        // Verify that setIndexMappings and setIndexSettings are called with correct values
+        verify(metadataStore).setIndexMappings("test-index", "{\"properties\": {\"field1\": {\"type\": \"text\"}}}");
+        verify(metadataStore).setIndexSettings("test-index", "{\"number_of_shards\": 1}");
+    }
+
+    @Test
+    void testCreateIndex_WithActiveFlag() throws Exception {
+        // Given
+        String createIndexRequestJson = """
+            {
+                "index_name": "active-index",
+                "active": true
+            }
+            """;
+        List<SearchUnit> availableSearchUnits = createMockSearchUnits();
+
+        when(metadataStore.getIndexConfig("active-index")).thenReturn(Optional.empty());
+        when(metadataStore.getAllSearchUnits()).thenReturn(availableSearchUnits);
+        when(metadataStore.createIndexConfig(any(Index.class))).thenReturn("doc-id-456");
+
+        // When
+        indexManager.createIndex(createIndexRequestJson);
+
+        // Then
+        ArgumentCaptor<Index> indexCaptor = ArgumentCaptor.forClass(Index.class);
+        verify(metadataStore).createIndexConfig(indexCaptor.capture());
+
+        Index capturedIndex = indexCaptor.getValue();
+        assertThat(capturedIndex.getIndexName()).isEqualTo("active-index");
+        assertThat(capturedIndex.isActive()).isTrue();
+    }
+
+    @Test
+    void testCreateIndex_NoAvailableSearchUnits() throws Exception {
+        // Given
+        String createIndexRequestJson = """
+            {
+                "index_name": "test-index",
+                "active": false
+            }
+            """;
+        List<SearchUnit> emptySearchUnits = new ArrayList<>();
+
+        when(metadataStore.getIndexConfig("test-index")).thenReturn(Optional.empty());
+        when(metadataStore.getAllSearchUnits()).thenReturn(emptySearchUnits);
+
+        // When/Then
+        assertThatThrownBy(() -> indexManager.createIndex(createIndexRequestJson))
+                .isInstanceOf(Exception.class)
+                .hasMessageContaining("No search units available for index allocation");
+
+        verify(metadataStore).getAllSearchUnits();
+        verify(metadataStore, never()).createIndexConfig(any(Index.class));
+    }
+
+    @Test
+    void testCreateIndex_InvalidJson() {
+        // Given
+        String invalidJson = "{ invalid json }";
+
+        // When/Then
+        assertThatThrownBy(() -> indexManager.createIndex(invalidJson))
+                .isInstanceOf(Exception.class);
+
+        // Note: We can't verify method calls that throw exceptions without handling them
+    }
+
+    @Test
+    void testCreateIndex_IndexAlreadyExists() throws Exception {
+        // Given
+        String createIndexRequestJson = """
+            {
+                "index_name": "existing-index",
+                "active": false
+            }
+            """;
+
+        when(metadataStore.getIndexConfig("existing-index"))
+                .thenReturn(Optional.of("existing config"));
+
+        // When
+        indexManager.createIndex(createIndexRequestJson);
+
+        // Then
+        verify(metadataStore).getIndexConfig("existing-index");
+        verify(metadataStore, never()).getAllSearchUnits();
+        verify(metadataStore, never()).createIndexConfig(any(Index.class));
+    }
+
+    @Test
+    void testDeleteIndex_Success() throws Exception {
+        // Given
+        String indexConfig = """
+            {
+                "index_name": "delete-me-index",
+                "active": true
+            }
+            """;
+
+        // When
+        indexManager.deleteIndex(indexConfig);
+
+        // Then
+        // Since deleteIndex just logs currently, we verify it doesn't throw
+        // In a real implementation, you'd verify the deletion logic
+    }
+
+    @Test
+    void testCreateIndexRequest_DefaultValues() throws Exception {
+        // This test verifies the inner CreateIndexRequest class behavior
+        String minimalJson = """
+            {
+                "index_name": "minimal-index"
+            }
+            """;
+
+        List<SearchUnit> availableSearchUnits = createMockSearchUnits();
+        when(metadataStore.getIndexConfig("minimal-index")).thenReturn(Optional.empty());
+        when(metadataStore.getAllSearchUnits()).thenReturn(availableSearchUnits);
+        when(metadataStore.createIndexConfig(any(Index.class))).thenReturn("doc-id");
+
+        // When
+        indexManager.createIndex(minimalJson);
+
+        // Then
+        ArgumentCaptor<Index> indexCaptor = ArgumentCaptor.forClass(Index.class);
+        verify(metadataStore).createIndexConfig(indexCaptor.capture());
+
+        Index capturedIndex = indexCaptor.getValue();
+        assertThat(capturedIndex.getIndexName()).isEqualTo("minimal-index");
+        assertThat(capturedIndex.isActive()).isFalse(); // Default value
+    }
+
+    private List<SearchUnit> createMockSearchUnits() {
+        List<SearchUnit> searchUnits = new ArrayList<>();
+        
+        SearchUnit unit1 = new SearchUnit();
+        unit1.setName("node-1");
+        unit1.setRole("primary");
+        unit1.setStatePulled(io.clustercontroller.enums.HealthState.GREEN);
+        searchUnits.add(unit1);
+
+        SearchUnit unit2 = new SearchUnit();
+        unit2.setName("node-2");
+        unit2.setRole("replica");
+        unit2.setStatePulled(io.clustercontroller.enums.HealthState.GREEN);
+        searchUnits.add(unit2);
+
+        SearchUnit unit3 = new SearchUnit();
+        unit3.setName("node-3");
+        unit3.setRole("ingest");
+        unit3.setStatePulled(io.clustercontroller.enums.HealthState.GREEN);
+        searchUnits.add(unit3);
+
+        return searchUnits;
+    }
+
+    @Test
+    void testCreateIndex_WithoutMappingsAndSettings() throws Exception {
+        // Given
+        String indexName = "minimal-index";
+        String createIndexRequestJson = """
+            {
+                "index_name": "minimal-index",
+                "active": false
+            }
+            """;
+        List<SearchUnit> availableSearchUnits = createMockSearchUnits();
+
+        // Mock dependencies
+        when(metadataStore.getIndexConfig(indexName)).thenReturn(Optional.empty());
+        when(metadataStore.getAllSearchUnits()).thenReturn(availableSearchUnits);
+        when(metadataStore.createIndexConfig(any(Index.class))).thenReturn("doc-id");
+
+        // When
+        indexManager.createIndex(createIndexRequestJson);
+
+        // Then
+        verify(metadataStore).createIndexConfig(any(Index.class));
+        verify(metadataStore).getAllSearchUnits();
+        
+        // Verify that setIndexMappings and setIndexSettings are NOT called when not provided
+        verify(metadataStore, never()).setIndexMappings(anyString(), anyString());
+        verify(metadataStore, never()).setIndexSettings(anyString(), anyString());
+    }
+
+    @Test
+    void testCreateIndex_WithOnlyMappings() throws Exception {
+        // Given
+        String indexName = "mappings-only-index";
+        String createIndexRequestJson = """
+            {
+                "index_name": "mappings-only-index",
+                "active": false,
+                "mappings": "{\\"properties\\": {\\"title\\": {\\"type\\": \\"text\\"}}}"
+            }
+            """;
+        List<SearchUnit> availableSearchUnits = createMockSearchUnits();
+
+        // Mock dependencies
+        when(metadataStore.getIndexConfig(indexName)).thenReturn(Optional.empty());
+        when(metadataStore.getAllSearchUnits()).thenReturn(availableSearchUnits);
+        when(metadataStore.createIndexConfig(any(Index.class))).thenReturn("doc-id");
+
+        // When
+        indexManager.createIndex(createIndexRequestJson);
+
+        // Then
+        verify(metadataStore).createIndexConfig(any(Index.class));
+        verify(metadataStore).setIndexMappings("mappings-only-index", "{\"properties\": {\"title\": {\"type\": \"text\"}}}");
+        verify(metadataStore, never()).setIndexSettings(anyString(), anyString());
+    }
+
+    @Test
+    void testCreateIndex_WithOnlySettings() throws Exception {
+        // Given
+        String indexName = "settings-only-index";
+        String createIndexRequestJson = """
+            {
+                "index_name": "settings-only-index",
+                "active": false,
+                "settings": "{\\"number_of_replicas\\": 2}"
+            }
+            """;
+        List<SearchUnit> availableSearchUnits = createMockSearchUnits();
+
+        // Mock dependencies
+        when(metadataStore.getIndexConfig(indexName)).thenReturn(Optional.empty());
+        when(metadataStore.getAllSearchUnits()).thenReturn(availableSearchUnits);
+        when(metadataStore.createIndexConfig(any(Index.class))).thenReturn("doc-id");
+
+        // When
+        indexManager.createIndex(createIndexRequestJson);
+
+        // Then
+        verify(metadataStore).createIndexConfig(any(Index.class));
+        verify(metadataStore, never()).setIndexMappings(anyString(), anyString());
+        verify(metadataStore).setIndexSettings("settings-only-index", "{\"number_of_replicas\": 2}");
+    }
+}

--- a/src/test/java/io/clustercontroller/indices/IndexManagerTest.java
+++ b/src/test/java/io/clustercontroller/indices/IndexManagerTest.java
@@ -40,7 +40,6 @@ class IndexManagerTest {
         String createIndexRequestJson = """
             {
                 "index_name": "test-index",
-                "active": false,
                 "mappings": "{\\"properties\\": {\\"field1\\": {\\"type\\": \\"text\\"}}}",
                 "settings": "{\\"number_of_shards\\": 1}"
             }
@@ -60,7 +59,6 @@ class IndexManagerTest {
 
         Index capturedIndex = indexCaptor.getValue();
         assertThat(capturedIndex.getIndexName()).isEqualTo(indexName);
-        assertThat(capturedIndex.isActive()).isFalse();
         assertThat(capturedIndex.getShardReplicaCount()).isNotNull();
         assertThat(capturedIndex.getAllocationPlan()).isNotNull();
         assertThat(capturedIndex.getCreatedAt()).isNotNull();
@@ -72,40 +70,13 @@ class IndexManagerTest {
         verify(metadataStore).setIndexSettings("test-index", "{\"number_of_shards\": 1}");
     }
 
-    @Test
-    void testCreateIndex_WithActiveFlag() throws Exception {
-        // Given
-        String createIndexRequestJson = """
-            {
-                "index_name": "active-index",
-                "active": true
-            }
-            """;
-        List<SearchUnit> availableSearchUnits = createMockSearchUnits();
-
-        when(metadataStore.getIndexConfig("active-index")).thenReturn(Optional.empty());
-        when(metadataStore.getAllSearchUnits()).thenReturn(availableSearchUnits);
-        when(metadataStore.createIndexConfig(any(Index.class))).thenReturn("doc-id-456");
-
-        // When
-        indexManager.createIndex(createIndexRequestJson);
-
-        // Then
-        ArgumentCaptor<Index> indexCaptor = ArgumentCaptor.forClass(Index.class);
-        verify(metadataStore).createIndexConfig(indexCaptor.capture());
-
-        Index capturedIndex = indexCaptor.getValue();
-        assertThat(capturedIndex.getIndexName()).isEqualTo("active-index");
-        assertThat(capturedIndex.isActive()).isTrue();
-    }
 
     @Test
     void testCreateIndex_NoAvailableSearchUnits() throws Exception {
         // Given
         String createIndexRequestJson = """
             {
-                "index_name": "test-index",
-                "active": false
+                "index_name": "test-index"
             }
             """;
         List<SearchUnit> emptySearchUnits = new ArrayList<>();
@@ -139,8 +110,7 @@ class IndexManagerTest {
         // Given
         String createIndexRequestJson = """
             {
-                "index_name": "existing-index",
-                "active": false
+                "index_name": "existing-index"
             }
             """;
 
@@ -161,8 +131,7 @@ class IndexManagerTest {
         // Given
         String indexConfig = """
             {
-                "index_name": "delete-me-index",
-                "active": true
+                "index_name": "delete-me-index"
             }
             """;
 
@@ -197,7 +166,6 @@ class IndexManagerTest {
 
         Index capturedIndex = indexCaptor.getValue();
         assertThat(capturedIndex.getIndexName()).isEqualTo("minimal-index");
-        assertThat(capturedIndex.isActive()).isFalse(); // Default value
     }
 
     private List<SearchUnit> createMockSearchUnits() {
@@ -230,8 +198,7 @@ class IndexManagerTest {
         String indexName = "minimal-index";
         String createIndexRequestJson = """
             {
-                "index_name": "minimal-index",
-                "active": false
+                "index_name": "minimal-index"
             }
             """;
         List<SearchUnit> availableSearchUnits = createMockSearchUnits();
@@ -260,7 +227,6 @@ class IndexManagerTest {
         String createIndexRequestJson = """
             {
                 "index_name": "mappings-only-index",
-                "active": false,
                 "mappings": "{\\"properties\\": {\\"title\\": {\\"type\\": \\"text\\"}}}"
             }
             """;
@@ -287,7 +253,6 @@ class IndexManagerTest {
         String createIndexRequestJson = """
             {
                 "index_name": "settings-only-index",
-                "active": false,
                 "settings": "{\\"number_of_replicas\\": 2}"
             }
             """;

--- a/src/test/java/io/clustercontroller/store/EtcdMetadataStoreTest.java
+++ b/src/test/java/io/clustercontroller/store/EtcdMetadataStoreTest.java
@@ -357,15 +357,16 @@ public class EtcdMetadataStoreTest {
         EtcdMetadataStore store = newStore();
 
         GetResponse resp = mockGetResponse(Arrays.asList(
-                mockKv("{\"settings\":{\"refresh_interval\":\"1s\"}}"),
-                mockKv("{\"settings\":{\"number_of_shards\":3}}")
+                mockKv("{\"index_name\":\"test-index-1\",\"shard_replica_count\":[1],\"active\":true}"),
+                mockKv("{\"index_name\":\"test-index-2\",\"shard_replica_count\":[2],\"active\":false}")
         ));
         when(mockKv.get(any(ByteSequence.class), any(GetOption.class)))
                 .thenReturn(CompletableFuture.completedFuture(resp));
 
-        List<String> configs = store.getAllIndexConfigs();
+        List<Index> configs = store.getAllIndexConfigs();
         assertThat(configs).hasSize(2);
-        assertThat(configs.get(0)).contains("settings");
+        assertThat(configs.get(0).getIndexName()).isEqualTo("test-index-1");
+        assertThat(configs.get(1).getIndexName()).isEqualTo("test-index-2");
     }
 
     @Test

--- a/src/test/java/io/clustercontroller/store/EtcdMetadataStoreTest.java
+++ b/src/test/java/io/clustercontroller/store/EtcdMetadataStoreTest.java
@@ -1,6 +1,7 @@
 package io.clustercontroller.store;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.clustercontroller.models.Index;
 import io.clustercontroller.models.SearchUnit;
 import io.clustercontroller.models.TaskMetadata;
 import io.etcd.jetcd.*;
@@ -10,6 +11,7 @@ import io.etcd.jetcd.KeyValue;
 import io.etcd.jetcd.kv.PutResponse;
 import io.etcd.jetcd.options.GetOption;
 import org.junit.jupiter.api.*;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -21,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -398,7 +401,8 @@ public class EtcdMetadataStoreTest {
         when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
                 .thenReturn(CompletableFuture.completedFuture(mockPutResponse()));
 
-        String name = store.createIndexConfig("test-index", "{\"x\":1}");
+        Index testIndex = new Index("test-index", List.of(1));
+        String name = store.createIndexConfig(testIndex);
         assertThat(name).isEqualTo("test-index");
         verify(mockKv).put(any(ByteSequence.class), any(ByteSequence.class));
     }
@@ -410,7 +414,8 @@ public class EtcdMetadataStoreTest {
         when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
                 .thenReturn(CompletableFuture.completedFuture(mockPutResponse()));
 
-        store.updateIndexConfig("user-index", "{\"y\":2}");
+        Index testIndex = new Index("user-index", List.of(1));
+        store.updateIndexConfig(testIndex);
         verify(mockKv).put(any(ByteSequence.class), any(ByteSequence.class));
     }
 
@@ -441,6 +446,90 @@ public class EtcdMetadataStoreTest {
         assertThatThrownBy(() -> store.deleteIndexConfig("test-index"))
                 .isInstanceOf(Exception.class)
                 .hasMessageContaining("Failed to delete index config from etcd");
+    }
+
+    @Test
+    public void testSetIndexMappings() throws Exception {
+        EtcdMetadataStore store = newStore();
+        String indexName = "test-index";
+        String mappings = "{\"properties\": {\"field1\": {\"type\": \"text\"}}}";
+
+        // Mock successful put response
+        PutResponse mockPutResponse = mock(PutResponse.class);
+        when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mockPutResponse));
+
+        // Execute
+        store.setIndexMappings(indexName, mappings);
+
+        // Verify the put call was made with correct key and value
+        ArgumentCaptor<ByteSequence> keyCaptor = ArgumentCaptor.forClass(ByteSequence.class);
+        ArgumentCaptor<ByteSequence> valueCaptor = ArgumentCaptor.forClass(ByteSequence.class);
+        verify(mockKv).put(keyCaptor.capture(), valueCaptor.capture());
+
+        String capturedKey = keyCaptor.getValue().toString(UTF_8);
+        String capturedValue = valueCaptor.getValue().toString(UTF_8);
+
+        assertThat(capturedKey).contains("test-cluster/indices/test-index/mappings");
+        assertThat(capturedValue).isEqualTo(mappings);
+    }
+
+    @Test
+    public void testSetIndexMappingsWithException() throws Exception {
+        EtcdMetadataStore store = newStore();
+        String indexName = "test-index";
+        String mappings = "{\"properties\": {\"field1\": {\"type\": \"text\"}}}";
+
+        // Mock etcd failure
+        when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("etcd connection failed")));
+
+        // Verify exception is propagated
+        assertThatThrownBy(() -> store.setIndexMappings(indexName, mappings))
+                .isInstanceOf(Exception.class)
+                .hasMessageContaining("Failed to set index mappings in etcd");
+    }
+
+    @Test
+    public void testSetIndexSettings() throws Exception {
+        EtcdMetadataStore store = newStore();
+        String indexName = "test-index";
+        String settings = "{\"number_of_shards\": 1, \"number_of_replicas\": 2}";
+
+        // Mock successful put response
+        PutResponse mockPutResponse = mock(PutResponse.class);
+        when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.completedFuture(mockPutResponse));
+
+        // Execute
+        store.setIndexSettings(indexName, settings);
+
+        // Verify the put call was made with correct key and value
+        ArgumentCaptor<ByteSequence> keyCaptor = ArgumentCaptor.forClass(ByteSequence.class);
+        ArgumentCaptor<ByteSequence> valueCaptor = ArgumentCaptor.forClass(ByteSequence.class);
+        verify(mockKv).put(keyCaptor.capture(), valueCaptor.capture());
+
+        String capturedKey = keyCaptor.getValue().toString(UTF_8);
+        String capturedValue = valueCaptor.getValue().toString(UTF_8);
+
+        assertThat(capturedKey).contains("test-cluster/indices/test-index/settings");
+        assertThat(capturedValue).isEqualTo(settings);
+    }
+
+    @Test
+    public void testSetIndexSettingsWithException() throws Exception {
+        EtcdMetadataStore store = newStore();
+        String indexName = "test-index";
+        String settings = "{\"number_of_shards\": 1}";
+
+        // Mock etcd failure
+        when(mockKv.put(any(ByteSequence.class), any(ByteSequence.class)))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("etcd timeout")));
+
+        // Verify exception is propagated
+        assertThatThrownBy(() -> store.setIndexSettings(indexName, settings))
+                .isInstanceOf(Exception.class)
+                .hasMessageContaining("Failed to set index settings in etcd");
     }
 
     // ------------------------- lifecycle -------------------------

--- a/src/test/java/io/clustercontroller/tasks/impl/CreateIndexTaskTest.java
+++ b/src/test/java/io/clustercontroller/tasks/impl/CreateIndexTaskTest.java
@@ -29,7 +29,7 @@ class CreateIndexTaskTest {
     }
     
     @Test
-    void testCreateIndexTaskExecution() {
+    void testCreateIndexTaskExecution() throws Exception {
         String taskName = "create-index-task";
         String input = "index-config";
         CreateIndexTask task = new CreateIndexTask(taskName, 1, input, TASK_SCHEDULE_ONCE);
@@ -56,7 +56,7 @@ class CreateIndexTaskTest {
     }
     
     @Test
-    void testCreateIndexTaskExecutionFailure() {
+    void testCreateIndexTaskExecutionFailure() throws Exception {
         String taskName = "create-index-task";
         String input = "invalid-config";
         CreateIndexTask task = new CreateIndexTask(taskName, 1, input, TASK_SCHEDULE_ONCE);

--- a/src/test/java/io/clustercontroller/tasks/impl/DeleteIndexTaskTest.java
+++ b/src/test/java/io/clustercontroller/tasks/impl/DeleteIndexTaskTest.java
@@ -29,7 +29,7 @@ class DeleteIndexTaskTest {
     }
     
     @Test
-    void testDeleteIndexTaskExecution() {
+    void testDeleteIndexTaskExecution() throws Exception {
         String taskName = "delete-index-task";
         String input = "index-config";
         DeleteIndexTask task = new DeleteIndexTask(taskName, 1, input, TASK_SCHEDULE_ONCE);
@@ -56,7 +56,7 @@ class DeleteIndexTaskTest {
     }
     
     @Test
-    void testDeleteIndexTaskExecutionFailure() {
+    void testDeleteIndexTaskExecutionFailure() throws Exception {
         String taskName = "delete-index-task";
         String input = "invalid-config";
         DeleteIndexTask task = new DeleteIndexTask(taskName, 1, input, TASK_SCHEDULE_ONCE);

--- a/src/test/java/io/clustercontroller/tasks/impl/PlanShardAllocationTaskTest.java
+++ b/src/test/java/io/clustercontroller/tasks/impl/PlanShardAllocationTaskTest.java
@@ -29,7 +29,7 @@ class PlanShardAllocationTaskTest {
     }
     
     @Test
-    void testPlanShardAllocationTaskExecution() {
+    void testPlanShardAllocationTaskExecution() throws Exception {
         String taskName = "plan-shard-allocation-task";
         String input = "";
         PlanShardAllocationTask task = new PlanShardAllocationTask(taskName, 1, input, TASK_SCHEDULE_ONCE);
@@ -56,7 +56,7 @@ class PlanShardAllocationTaskTest {
     }
     
     @Test
-    void testPlanShardAllocationTaskExecutionFailure() {
+    void testPlanShardAllocationTaskExecutionFailure() throws Exception {
         String taskName = "plan-shard-allocation-task";
         String input = "";
         PlanShardAllocationTask task = new PlanShardAllocationTask(taskName, 1, input, TASK_SCHEDULE_ONCE);


### PR DESCRIPTION
Basic logic is: 
1) Remove all planned allocations for this index 
2) Delete the index configuration from etcd
3)  Clean up goal states for this deleted index (delete localShards for this index) 

Built off of dc/create_index branch since models are shared 