### PR TITLE
Adding actuator dep for health endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,13 @@
             <version>3.1.5</version>
         </dependency>
         
+        <!-- Spring Boot Actuator for health endpoints -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>3.1.5</version>
+        </dependency>
+        
         <!-- JSON Processing -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Need to expose /health endpoint, need this dependency 

`export NODE_NAME=cluster-controller-node-1                       
export MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE=health,info
export MANAGEMENT_ENDPOINT_HEALTH_SHOW_DETAILS=always
mvn spring-boot:run`

`curl http://localhost:8080/actuator/health

{"status":"UP","components":{"diskSpace":{"status":"UP","details":{"total":994662584320,"free":387985170432,"threshold":10485760,"path":"/Users/darby.clement/search/cluster-controller/.","exists":true}},"ping":{"status":"UP"}}}%  `