### PR TITLE
Leader Election refactor / fix

### DIFF
--- a/src/main/java/io/clustercontroller/TaskManager.java
+++ b/src/main/java/io/clustercontroller/TaskManager.java
@@ -115,6 +115,12 @@ public class TaskManager {
     
     private void processTaskLoop() {
         try {
+            // Only process tasks if this node is the leader
+            if (!metadataStore.isLeader()) {
+                log.debug("Skipping task processing - not the leader");
+                return;
+            }
+            
             log.info("Running task processing loop - checking for tasks");
             
             List<TaskMetadata> taskMetadataList = getAllTasks();

--- a/src/main/java/io/clustercontroller/election/LeaderElection.java
+++ b/src/main/java/io/clustercontroller/election/LeaderElection.java
@@ -1,15 +1,18 @@
 package io.clustercontroller.election;
 
-import io.clustercontroller.store.EtcdMetadataStore;
-import io.clustercontroller.util.EnvironmentUtils;
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.Election;
+import io.etcd.jetcd.lease.LeaseGrantResponse;
+import io.etcd.jetcd.lease.LeaseKeepAliveResponse;
+import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.clustercontroller.config.Constants.*;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Handles leader election logic for the cluster controller.
@@ -18,76 +21,110 @@ import static io.clustercontroller.config.Constants.*;
 @Slf4j
 public class LeaderElection {
     
-    private static final long LEADER_ELECTION_POLL_INTERVAL_MS = 1000L; // 1 second
-    private static final long DEFAULT_LEADER_ELECTION_TIMEOUT_MS = 30_000L; // 30 seconds
+    private static final String CONTROLLER_ELECTION_KEY = "/controller-leader-election";
     
-    private final EtcdMetadataStore metadataStore;
-    private final String currentNodeName;
+    private final Client etcdClient;
+    private final String nodeId;
+    private final AtomicBoolean isLeader;
     
-    public LeaderElection(EtcdMetadataStore metadataStore) {
-        this.metadataStore = metadataStore;
-        this.currentNodeName = EnvironmentUtils.getRequiredEnv("NODE_NAME");
+    /**
+     * Constructor for LeaderElection
+     * Leader election is at the controller level - the winning controller manages all clusters.
+     * 
+     * @param etcdClient the etcd client instance
+     * @param nodeId the unique identifier for this node
+     * @param isLeader atomic boolean to track leader state (shared with caller)
+     */
+    public LeaderElection(Client etcdClient, String nodeId, AtomicBoolean isLeader) {
+        this.etcdClient = etcdClient;
+        this.nodeId = nodeId;
+        this.isLeader = isLeader;
     }
     
     /**
-     * Wait until this node becomes the leader with default timeout.
+     * Start the leader election process asynchronously.
+     * This method initiates an etcd election campaign and returns immediately.
+     * The election runs in the background, and the CompletableFuture completes when leadership is acquired.
      * 
-     * @throws InterruptedException if the thread is interrupted
-     * @throws TimeoutException if leader election times out
+     * @return CompletableFuture that completes with true when this node becomes leader
      */
-    public void waitUntilLeader() throws InterruptedException, TimeoutException {
-        waitUntilLeader(DEFAULT_LEADER_ELECTION_TIMEOUT_MS);
-    }
-    
-    /**
-     * Wait until this node becomes the leader with specified timeout.
-     * Uses CountDownLatch for better concurrency handling instead of Thread.sleep.
-     * 
-     * @param timeoutMs maximum time to wait for leader election in milliseconds
-     * @throws InterruptedException if the thread is interrupted
-     * @throws TimeoutException if leader election times out
-     */
-    public void waitUntilLeader(long timeoutMs) throws InterruptedException, TimeoutException {
-        log.info("LeaderElection - Starting leader election process...");
-        log.info("LeaderElection - Current node: {}", currentNodeName);
+    public CompletableFuture<Boolean> startElection() {
+        log.info("LeaderElection - Starting controller-level leader election for node: {}", nodeId);
+        log.info("LeaderElection - Election key: {}", CONTROLLER_ELECTION_KEY);
         
-        long startTime = System.currentTimeMillis();
-        CountDownLatch pollLatch = new CountDownLatch(1);
-        
-        // Use CompletableFuture to handle the polling logic
-        CompletableFuture<Void> leaderWaitFuture = CompletableFuture.runAsync(() -> {
+        Election election = etcdClient.getElectionClient();
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+
+        CompletableFuture.runAsync(() -> {
             try {
-                while (!metadataStore.isLeader()) {
-                    // Check timeout
-                    if (System.currentTimeMillis() - startTime > timeoutMs) {
-                        throw new RuntimeException("Leader election timeout exceeded: " + timeoutMs + "ms");
+                log.info("LeaderElection - Node {} attempting to campaign for controller leadership", nodeId);
+                
+                ByteSequence electionKeyBytes = ByteSequence.from(CONTROLLER_ELECTION_KEY, UTF_8);
+                ByteSequence nodeIdBytes = ByteSequence.from(nodeId, UTF_8);
+
+                // Create a lease for the election
+                long ttlSeconds = LEADER_ELECTION_TTL_SECONDS;
+                LeaseGrantResponse leaseGrant = etcdClient.getLeaseClient()
+                        .grant(ttlSeconds)
+                        .get();
+                long leaseId = leaseGrant.getID();
+                
+                log.info("LeaderElection - Node {} obtained lease ID: {} with TTL: {}s", nodeId, leaseId, ttlSeconds);
+
+                // Keep the lease alive
+                etcdClient.getLeaseClient().keepAlive(leaseId, new StreamObserver<LeaseKeepAliveResponse>() {
+                    @Override
+                    public void onNext(LeaseKeepAliveResponse res) {
+                        log.debug("LeaderElection - Lease keep-alive successful for node {}", nodeId);
                     }
                     
-                    // Wait for poll interval using CountDownLatch instead of Thread.sleep
-                    CountDownLatch sleepLatch = new CountDownLatch(1);
-                    sleepLatch.await(LEADER_ELECTION_POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
-                }
-                pollLatch.countDown();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException("Leader election interrupted", e);
+                    @Override
+                    public void onError(Throwable t) {
+                        log.error("LeaderElection - Lease keep-alive error for node {}: {}", nodeId, t.getMessage());
+                        isLeader.set(false);
+                        result.completeExceptionally(t);
+                    }
+                    
+                    @Override
+                    public void onCompleted() {
+                        log.warn("LeaderElection - Lease keep-alive completed for node {}, stepping down from leadership", nodeId);
+                        isLeader.set(false);
+                    }
+                });
+
+                log.info("LeaderElection - Node {} starting campaign with lease ID: {}", nodeId, leaseId);
+                
+                // Campaign for leadership - this blocks until leadership is acquired
+                election.campaign(electionKeyBytes, leaseId, nodeIdBytes)
+                        .thenAccept(leaderKey -> {
+                            log.info("LeaderElection - ✓ SUCCESS: Node {} has WON the election and is now the LEADER!", nodeId);
+                            isLeader.set(true);
+                            result.complete(true);
+                        })
+                        .exceptionally(ex -> {
+                            log.error("LeaderElection - Node {} failed during campaign: {}", nodeId, ex.getMessage(), ex);
+                            isLeader.set(false);
+                            result.completeExceptionally(ex);
+                            return null;
+                        });
+
             } catch (Exception e) {
-                throw new RuntimeException("Leader election failed", e);
+                log.error("LeaderElection - Election error for node {}: {}", nodeId, e.getMessage(), e);
+                isLeader.set(false);
+                result.completeExceptionally(e);
             }
         });
         
-        try {
-            // Wait for either success or timeout
-            if (!pollLatch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
-                leaderWaitFuture.cancel(true);
-                throw new TimeoutException("Leader election timed out after " + timeoutMs + "ms");
-            }
-            
-            log.info("LeaderElection - SUCCESS: This node ({}) has become the leader!", currentNodeName);
-            
-        } catch (InterruptedException e) {
-            leaderWaitFuture.cancel(true);
-            throw e;
-        }
+        log.info("LeaderElection - Election initiated asynchronously for node: {}", nodeId);
+        return result;
+    }
+    
+    /**
+     * Check if this node is currently the leader
+     * 
+     * @return true if this node is the leader, false otherwise
+     */
+    public boolean isLeader() {
+        return isLeader.get();
     }
 }

--- a/src/main/java/io/clustercontroller/store/EtcdMetadataStore.java
+++ b/src/main/java/io/clustercontroller/store/EtcdMetadataStore.java
@@ -20,9 +20,7 @@ import io.etcd.jetcd.op.CmpTarget;
 import io.etcd.jetcd.op.Op;
 import io.etcd.jetcd.options.DeleteOption;
 import io.etcd.jetcd.options.GetOption;
-import io.etcd.jetcd.options.LeaseOption;
 import io.etcd.jetcd.options.PutOption;
-import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 
 import java.nio.charset.StandardCharsets;
@@ -33,7 +31,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static io.clustercontroller.config.Constants.PATH_DELIMITER;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static io.clustercontroller.config.Constants.*;
 
 /**
  * etcd-based implementation of MetadataStore.

--- a/src/main/java/io/clustercontroller/store/MetadataStore.java
+++ b/src/main/java/io/clustercontroller/store/MetadataStore.java
@@ -180,6 +180,10 @@ public interface MetadataStore {
     void close() throws Exception;
     
     /**
-     * Get the cluster name this metadata store is connected to
+     * Check if this controller instance is the leader.
+     * Only the leader should perform active management operations.
+     * 
+     * @return true if this instance is the leader, false otherwise
      */
+    boolean isLeader();
 }

--- a/src/test/java/io/clustercontroller/store/LeaderElectionTest.java
+++ b/src/test/java/io/clustercontroller/store/LeaderElectionTest.java
@@ -86,7 +86,7 @@ class LeaderElectionTest {
                 .thenReturn(campaignFuture);
 
         // Start leader election
-        CompletableFuture<Boolean> electionResult = etcdStore.startLeaderElection();
+        CompletableFuture<Boolean> electionResult = etcdStore.getLeaderElection().startElection();
         
         // Wait for result with timeout
         Boolean isLeader = electionResult.get(5, TimeUnit.SECONDS);
@@ -121,7 +121,7 @@ class LeaderElectionTest {
                 .thenReturn(campaignFuture);
 
         // Start leader election
-        CompletableFuture<Boolean> electionResult = etcdStore.startLeaderElection();
+        CompletableFuture<Boolean> electionResult = etcdStore.getLeaderElection().startElection();
         
         // Verify election failure
         assertThrows(Exception.class, () -> electionResult.get(5, TimeUnit.SECONDS));
@@ -153,7 +153,7 @@ class LeaderElectionTest {
         }).when(leaseClient).keepAlive(anyLong(), any(StreamObserver.class));
 
         // Start leader election
-        CompletableFuture<Boolean> electionResult = etcdStore.startLeaderElection();
+        CompletableFuture<Boolean> electionResult = etcdStore.getLeaderElection().startElection();
         
         // Verify keep alive error causes election failure
         assertThrows(Exception.class, () -> electionResult.get(5, TimeUnit.SECONDS));
@@ -190,7 +190,7 @@ class LeaderElectionTest {
         }).when(leaseClient).keepAlive(anyLong(), any(StreamObserver.class));
 
         // Start leader election
-        CompletableFuture<Boolean> electionResult = etcdStore.startLeaderElection();
+        CompletableFuture<Boolean> electionResult = etcdStore.getLeaderElection().startElection();
         
         // Wait for initial election success
         Boolean isLeader = electionResult.get(5, TimeUnit.SECONDS);
@@ -218,8 +218,8 @@ class LeaderElectionTest {
                 .thenReturn(CompletableFuture.completedFuture(campaignResponse));
 
         // Start multiple leader elections
-        CompletableFuture<Boolean> election1 = etcdStore.startLeaderElection();
-        CompletableFuture<Boolean> election2 = etcdStore.startLeaderElection();
+        CompletableFuture<Boolean> election1 = etcdStore.getLeaderElection().startElection();
+        CompletableFuture<Boolean> election2 = etcdStore.getLeaderElection().startElection();
         
         // Both should succeed
         assertTrue(election1.get(5, TimeUnit.SECONDS));
@@ -289,15 +289,15 @@ class LeaderElectionTest {
                 .thenReturn(CompletableFuture.completedFuture(campaignResponse));
 
         // Start election
-        CompletableFuture<Boolean> electionResult = etcdStore.startLeaderElection();
+        CompletableFuture<Boolean> electionResult = etcdStore.getLeaderElection().startElection();
         
         // Wait for election to complete
         Boolean isLeader = electionResult.get(5, TimeUnit.SECONDS);
         assertTrue(isLeader);
         
-        // Verify that the election key is formed correctly (using default cluster name)
+        // Verify that the election key is formed correctly (controller-level, not cluster-specific)
         verify(electionClient).campaign(
-                argThat(key -> key.toString().contains("default-cluster-election")),
+                argThat(key -> key.toString().contains("/controller-leader-election")),
                 eq(12345L),
                 any(ByteSequence.class)
         );


### PR DESCRIPTION
Since refactoring has been done since leader election was implemented, there was a miss where LeaderElection class was not being used and leader election was not working. Fixing this by refactoring all leader election code into LeaderElection class, and using this class inside ETCDMetadataStore

Testing:
in logs:

2025-10-07T23:07:32.885Z INFO 1 --- [ntloop-thread-0] i.c.election.LeaderElection : LeaderElection - ✓ SUCCESS: Node phx50-i4u has WON the election and is now the LEADER!

![Uploading Screenshot 2025-10-07 at 5.21.33 PM.png…]()


