### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetcd.version>0.7.3</jetcd.version>
+        <jetcd.version>0.8.6</jetcd.version>
     </properties>
     
     <dependencies>
@@ -24,41 +24,41 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>3.1.5</version>
+            <version>3.5.8</version>
         </dependency>
         
         <!-- Spring Boot Actuator for health endpoints -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
-            <version>3.1.5</version>
+            <version>3.5.8</version>
         </dependency>
         
         <!-- JSON Processing -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.2</version>
+            <version>2.18.2</version>
         </dependency>
         
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.15.2</version>
+            <version>2.18.2</version>
         </dependency>
         
         <!-- Logging -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.4.11</version>
+            <version>1.5.15</version>
         </dependency>
         
         <!-- Lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
+            <version>1.18.40</version>
             <scope>provided</scope>
         </dependency>
         
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.7</version>
+            <version>2.0.16</version>
         </dependency>
         
         <!-- etcd client -->
@@ -80,21 +80,21 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.33</version>
+            <version>2.3</version>
         </dependency>
 
         <!-- Prometheus metrics -->
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.11.5</version>
+            <version>1.14.3</version>
         </dependency>
         
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.10.0</version>
+            <version>5.11.4</version>
             <scope>test</scope>
         </dependency>
         
@@ -102,21 +102,21 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.5.0</version>
+            <version>5.20.0</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>5.5.0</version>
+            <version>5.20.0</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
+            <version>3.27.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -127,7 +127,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>3.1.5</version>
+                <version>3.5.8</version>
                 <configuration>
                     <excludes>
                         <exclude>
@@ -141,7 +141,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>21</source>
                     <target>21</target>
@@ -151,7 +151,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.30</version>
+                            <version>1.18.40</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -160,7 +160,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.5.2</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/io/clustercontroller/config/ClusterControllerConfig.java
+++ b/src/main/java/io/clustercontroller/config/ClusterControllerConfig.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.LoaderOptions;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -51,7 +52,7 @@ public class ClusterControllerConfig {
 
 
     private ConfigModel loadYamlConfig() {
-        Yaml yaml = new Yaml(new Constructor(ConfigModel.class));
+        Yaml yaml = new Yaml(new Constructor(ConfigModel.class, new LoaderOptions()));
         InputStream inputStream = null;
         String loadedFrom = "";
 


### PR DESCRIPTION
In order to prepare for merging into the cluster-etcd repository, which builds with JDK25, we need to upgrade various dependencies (mostly Lombok and Mockito). While we're doing that, we can upgrade a bunch of dependencies to their latest versions:

spring-boot: 3.1.5 -> 3.5.8
Jackson: 2.15.2 -> 2.18.2
Logback: 1.4.11 -> 1.5.15
SLF4J: 2.0.7 -> 2.0.16
SnakeYAML: 1.33 -> 2.3
Micrometer Prometheus: 1.11.5 -> 1.14.3
JUnit: 5.10.0 -> 5.11.4
AssertJ: 3.24.2 -> 3.27.3
jetcd: 0.7.3 -> 0.8.6
Lombok: 1.18.30 -> 1.18.40

Some of the old versions had vulnerabilities, so upgrading them is important.